### PR TITLE
Unit 11: Modernize Kalshi positions widget (semantic tokens, canonical cards, terminal polish)

### DIFF
--- a/app/components/KalshiPositions.js
+++ b/app/components/KalshiPositions.js
@@ -74,16 +74,8 @@ const KalshiPositions = ({ id }) => {
   let secondAcctPnl = 950 * 100;
   overallPnL = overallPnL + secondAcctPnl;
   return (
-    <div
-      className={styles["positions-container"]}
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-      }}
-      id={id}
-    >
-      <h2 className={styles["positions-title"]}>Kalshi Positions</h2>
+    <div className={styles["positions-container"]} id={id}>
+      <h2 className="section-title">Kalshi Positions</h2>
 
       {/* Overall Profile P&L Display */}
       <div className={styles["total-pnl-container"]}>
@@ -100,17 +92,25 @@ const KalshiPositions = ({ id }) => {
           {formatPnL(overallPnL)}
         </p>
         {profileMetrics && (
-          <div
-            style={{
-              textAlign: "center",
-              marginTop: "1rem",
-              color: "#94a3b8",
-              fontSize: "0.9rem",
-            }}
-          >
-            <div>Markets Traded: {profileMetrics.num_markets_traded}</div>
-            <div>Volume: {profileMetrics.volume.toLocaleString()}</div>
-            <div>Open Interest: ${profileMetrics.open_interest}</div>
+          <div className={styles["profile-metrics"]}>
+            <div className={styles["metric"]}>
+              <span className={styles["metric-label"]}>Markets Traded</span>
+              <span className={styles["metric-value"]}>
+                {profileMetrics.num_markets_traded}
+              </span>
+            </div>
+            <div className={styles["metric"]}>
+              <span className={styles["metric-label"]}>Volume</span>
+              <span className={styles["metric-value"]}>
+                {profileMetrics.volume?.toLocaleString()}
+              </span>
+            </div>
+            <div className={styles["metric"]}>
+              <span className={styles["metric-label"]}>Open Interest</span>
+              <span className={styles["metric-value"]}>
+                ${profileMetrics.open_interest}
+              </span>
+            </div>
           </div>
         )}
       </div>
@@ -119,7 +119,7 @@ const KalshiPositions = ({ id }) => {
         <Grid container spacing={3} className={styles["positions-grid"]}>
           {positions.length === 0 ? <p>No open positions.</p> : null}
           {positions.map((position) => (
-            <Grid item key={position.id}>
+            <Grid key={position.id}>
               <div className={styles["position-card"]}>
                 <div className={styles["card-header"]}>
                   <span className={styles["category-badge"]}>
@@ -175,13 +175,7 @@ const KalshiPositions = ({ id }) => {
 
                   <div className={styles["detail-row"]}>
                     <span className={styles["detail-label"]}>P&L:</span>
-                    <div
-                      style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        alignItems: "flex-end",
-                      }}
-                    >
+                    <div className={styles["pnl-cell"]}>
                       <span
                         className={`${styles["detail-value"]} ${
                           position.pnl > 0
@@ -217,9 +211,10 @@ const KalshiPositions = ({ id }) => {
           ))}
         </Grid>
       </Box>
-      <p style={{
-        textAlign: "center"
-      }}>Discrepancies between Kalshi PNL and PNL above are due to group portfolios.</p>
+      <p className={styles["disclaimer"]}>
+        Discrepancies between Kalshi PNL and PNL above are due to group
+        portfolios.
+      </p>
 
       <Link
         href="https://kalshi.com/ideas/profiles/Turtlecap"

--- a/app/components/KalshiPositions.module.css
+++ b/app/components/KalshiPositions.module.css
@@ -2,29 +2,12 @@
 
 .positions-container {
   width: auto;
-  padding: 0 1rem 1rem 1rem;
-  color: var(--text-primary);
   max-width: 100%;
-}
-
-.positions-title {
-  text-align: center;
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin-bottom: 1rem;
-  margin-top: 0;
-  letter-spacing: -0.02em;
-}
-
-.positions-title::after {
-  content: "";
-  display: block;
-  width: 40px;
-  height: 1px;
-  background: var(--text-muted);
-  margin: 12px auto 0;
-  border-radius: 1px;
-  opacity: 0.4;
+  padding: 0 var(--space-md) var(--space-md);
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .positions-grid {
@@ -35,266 +18,39 @@
 .loading-container,
 .error-container {
   text-align: center;
-  padding: 2rem;
+  padding: var(--space-xl);
   font-size: 1rem;
   color: var(--text-secondary);
 }
 
 .error-container {
-  color: #ef4444;
-}
-
-.resumeLink {
-  text-decoration: none;
-  transition: all var(--transition-slow);
-  display: block;
-  margin-top: 2rem;
-  max-width: 350px;
-  width: 100%;
-}
-
-.resumeLink:hover {
-  transform: translateY(-3px);
-}
-
-.resumeCard {
-  background: var(--bg-card);
-  border-radius: var(--radius-md);
-  padding: 16px 24px;
-  border: 1px solid var(--border-color);
-  text-align: center;
-  transition: all var(--transition-slow);
-}
-
-.resumeLink:hover .resumeCard {
-  border-color: var(--border-hover);
-  background: var(--bg-card-hover);
-}
-
-.resumeCard h3 {
-  color: var(--text-primary);
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0;
-  letter-spacing: 0.02em;
-}
-
-.resumeCard h3::after {
-  content: ' \2192';
-  display: inline-block;
-  transition: transform var(--transition-fast);
-  margin-left: 8px;
-}
-
-.resumeLink:hover .resumeCard h3::after {
-  transform: translateX(4px);
-}
-
-.position-card {
-  background: var(--bg-card);
-  border-radius: var(--radius-md);
-  padding: 1.5rem;
-  width: 300px;
-  transition: all var(--transition-slow);
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--border-color);
-}
-
-.position-card:hover {
-  border-color: var(--border-hover);
-}
-
-.card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.category-badge {
-  background: var(--bg-card-hover);
-  color: var(--text-secondary);
-  padding: 0.25rem 0.75rem;
-  border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
-
-.position-badge {
-  padding: 0.25rem 0.75rem;
-  border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
-
-.position-badge.yes {
-  background: rgba(34, 197, 94, 0.12);
-  color: #86efac;
-}
-
-.position-badge.no {
-  background: rgba(239, 68, 68, 0.12);
-  color: #fca5a5;
-}
-
-.market-title {
-  font-size: 1rem;
-  font-weight: 600;
-  margin-bottom: 1rem;
-  color: var(--text-primary);
-  line-height: 1.4;
-  min-height: 3rem;
-}
-
-.subtitle {
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  margin-bottom: 1.25rem;
-  padding: 0.75rem;
-  background: var(--bg-card);
-  border-radius: var(--radius-sm);
-  border-left: 2px solid var(--border-hover);
-}
-
-.subtitle strong {
-  color: var(--text-primary);
-  margin-right: 0.5rem;
-}
-
-.position-details {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.detail-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.5rem 0;
-  border-bottom: 1px solid var(--border-color);
-}
-
-.detail-label {
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  font-weight: 500;
-}
-
-.detail-value {
-  color: var(--text-primary);
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-
-.pnl-positive {
-  color: #22c55e;
-}
-
-.pnl-negative {
-  color: #ef4444;
-}
-
-.pnl-neutral {
-  color: var(--text-muted);
-}
-
-.card-footer {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border-color);
-  margin-top: auto;
-}
-
-.ticker {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  font-family: "SF Mono", "Fira Code", monospace;
-  background: rgba(255, 255, 255, 0.03);
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.last-updated {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}
-
-/* Responsive Design */
-@media (max-width: 768px) {
-  .position-card {
-    padding: 1rem;
-  }
-
-  .market-title {
-    font-size: 0.95rem;
-    min-height: auto;
-  }
-
-  .card-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .resumeCard {
-    padding: 16px;
-  }
-}
-
-@media (max-width: 480px) {
-  .positions-container {
-    padding: 1rem 0.5rem;
-  }
-
-  .positions-title {
-    margin-bottom: 1rem;
-  }
-
-  .detail-row {
-    font-size: 0.8rem;
-  }
-
-  .resumeCard {
-    padding: 14px 12px;
-  }
+  color: var(--danger, #f87171);
 }
 
 /* Total P&L Section */
 .total-pnl-container {
   width: 100%;
   max-width: 400px;
-  margin: 1rem auto;
-  padding: 1.5rem;
+  margin: var(--space-md) auto;
+  padding: var(--space-lg);
   background: var(--bg-card);
-  border-radius: var(--radius-md);
   border: 1px solid var(--border-color);
-  transition: all var(--transition-slow);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--transition-base),
+    background var(--transition-base);
 }
 
 .total-pnl-container:hover {
   border-color: var(--border-hover);
+  background: var(--bg-card-hover);
 }
 
 .total-pnl-title {
   text-align: center;
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  margin-bottom: 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  margin-top: 0;
+  margin-bottom: var(--space-sm);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -306,16 +62,308 @@
   font-weight: 700;
   margin: 0;
   letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
 }
 
 .total-pnl-value.positive {
-  color: #22c55e;
+  color: var(--success, #4ade80);
 }
 
 .total-pnl-value.negative {
-  color: #ef4444;
+  color: var(--danger, #f87171);
 }
 
 .total-pnl-value.neutral {
-  color: var(--text-muted);
+  color: var(--text-secondary);
+}
+
+/* Profile metrics strip */
+.profile-metrics {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+  margin-top: var(--space-md);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--border-color);
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.metric-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.metric-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Position Cards */
+.position-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  width: 300px;
+  max-width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: transform var(--transition-base),
+    border-color var(--transition-base), box-shadow var(--transition-base),
+    background var(--transition-base);
+}
+
+.position-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
+  background: var(--bg-card-hover);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-md);
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.category-badge {
+  background: var(--bg-card-hover);
+  color: var(--text-secondary);
+  padding: 0.25rem 0.625rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.position-badge {
+  padding: 0.25rem 0.625rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+}
+
+.position-badge.yes {
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+}
+
+.position-badge.no {
+  color: var(--text-secondary);
+}
+
+.market-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 0;
+  margin-bottom: var(--space-md);
+  color: var(--text-primary);
+  line-height: 1.4;
+  min-height: 3rem;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin-bottom: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-card);
+  border-left: 2px solid var(--border-hover);
+  border-radius: var(--radius-sm);
+}
+
+.subtitle strong {
+  color: var(--text-primary);
+  font-weight: 600;
+  margin-right: var(--space-sm);
+}
+
+.position-details {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+}
+
+.detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.detail-label {
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.detail-value {
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.pnl-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-xs);
+}
+
+.pnl-positive {
+  color: var(--success, #4ade80);
+}
+
+.pnl-negative {
+  color: var(--danger, #f87171);
+}
+
+.pnl-neutral {
+  color: var(--text-secondary);
+}
+
+.card-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--border-color);
+  margin-top: auto;
+}
+
+.ticker {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+  font-family: "SF Mono", "Fira Code", monospace;
+  background: var(--bg-card-hover);
+  border: 1px solid var(--border-color);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+  align-self: flex-start;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.last-updated {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+/* Footnote */
+.disclaimer {
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  max-width: 60ch;
+  margin: var(--space-md) auto 0;
+}
+
+/* Profile link */
+.resumeLink {
+  text-decoration: none;
+  display: block;
+  margin-top: var(--space-xl);
+  max-width: 350px;
+  width: 100%;
+  border-radius: var(--radius-lg);
+  transition: transform var(--transition-base);
+}
+
+.resumeLink:hover {
+  transform: translateY(-2px);
+}
+
+.resumeLink:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
+.resumeCard {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-md) var(--space-lg);
+  text-align: center;
+  transition: border-color var(--transition-base),
+    background var(--transition-base), box-shadow var(--transition-base);
+}
+
+.resumeLink:hover .resumeCard {
+  border-color: var(--border-hover);
+  background: var(--bg-card-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.resumeCard h3 {
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: 0.02em;
+}
+
+.resumeCard h3::after {
+  content: " \2192";
+  display: inline-block;
+  color: var(--accent-brand, #d4a24e);
+  margin-left: var(--space-sm);
+  transition: transform var(--transition-base);
+}
+
+.resumeLink:hover .resumeCard h3::after {
+  transform: translateX(4px);
+}
+
+/* Responsive Design */
+@media (max-width: 640px) {
+  .positions-container {
+    padding: 0 var(--space-sm) var(--space-md);
+  }
+
+  .market-title {
+    min-height: auto;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .profile-metrics {
+    gap: var(--space-md);
+  }
+
+  .resumeCard {
+    padding: var(--space-md);
+  }
 }


### PR DESCRIPTION
## Summary
- Replaced ALL hardcoded P&L colors (`#22c55e`/`#ef4444`, plus `#94a3b8`, `#86efac`, `#fca5a5`) with semantic tokens with static fallbacks: `var(--success, #4ade80)` / `var(--danger, #f87171)`
- Removed the local section-title underline re-implementation; the heading now uses the global `.section-title` utility from globals.css
- Canonical card treatment on position cards and the Overall P&L card: `var(--bg-card)`, 1px `var(--border-color)`, `var(--radius-lg)`, `var(--space-lg)` padding; hover = translateY(-2px) + `var(--border-hover)` + `var(--shadow-md)` + `var(--bg-card-hover)` with explicit-property `var(--transition-base)` transitions (no `transition: all`)
- Finance-terminal polish: `font-variant-numeric: tabular-nums` on all numeric values, monochrome badges (semantic green/red reserved for P&L only), labels/badges at 0.8125rem in `--text-secondary` with 0.02em tracking, monospace ticker tag, profile metrics restyled as a label-over-value stat strip
- Moved all inline JSX styles into the CSS module; disclaimer, P&L cell, and container layout now tokenized
- One brass accent (`var(--accent-brand, #d4a24e)`): the profile-link arrow; `:focus-visible` brass outline on the link
- Breakpoints standardized: single 640px media query (was 768px/480px)
- Fixes from review: dropped the MUI v7-invalid `Grid item` prop (leaked to DOM as a React warning; v7 Grid children are items automatically) and guarded `profileMetrics.volume?.toLocaleString()`

## Functionality preserved
Data fetch from `/api/kalshi` + `/api/kalshi-profile`, loading state, error handling, P&L calculations and sign formatting, YES/NO badge logic, id anchor — all unchanged.

## Testing
- `npm run build` passes (lint fails pre-existing on main: `typescript` module missing for eslint-config-next)
- Dev server on :3111 returns HTTP 200; widget shows loading/error locally without prod env (expected)
- Grep confirms no `#22c55e`/`#ef4444` remain; every `styles[...]` key cross-checked against the CSS module (including dynamic `yes`/`no`/`positive`/`negative`/`neutral`)
- Tokens verified present for both dark and light themes; `--success`/`--danger`/`--accent-brand` use brief-mandated fallbacks until the globals.css unit lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)