### PR TITLE
Unit 6: Redesign resume page with header, download button, and framed PDF viewer

### DIFF
--- a/app/resume/page.js
+++ b/app/resume/page.js
@@ -2,16 +2,61 @@ import "./resume.css";
 import React from "react";
 import Bar from "../components/Bar";
 
+export const metadata = {
+  title: "Resume | Ashwin Iyer",
+  description:
+    "Ashwin Iyer's resume — view it online or download the PDF.",
+};
+
 export default function Resume() {
   return (
-    <div className="resume" style={{
-    }}>
+    <div className="resume">
       <Bar />
-      <iframe
-        src="https://ashwin-iyer1.github.io/resume/Ashwin_Iyer_CV.pdf"
-        className="resumeIframe"
-        frameBorder="0"
-      />
+      <header className="resume-header">
+        <div>
+          <p className="resume-eyebrow">Curriculum Vitae</p>
+          <h1 className="resume-title">Resume</h1>
+        </div>
+        <a
+          href="/resume.pdf"
+          download="Ashwin_Iyer_Resume.pdf"
+          className="resume-download"
+        >
+          <svg
+            className="resume-download-icon"
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M8 2.5v7.5m0 0 3-3m-3 3-3-3"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M3 13.5h10"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+          <span>Download PDF</span>
+        </a>
+      </header>
+      <div className="resume-viewer">
+        <iframe
+          src="https://ashwin-iyer1.github.io/resume/Ashwin_Iyer_CV.pdf"
+          className="resume-iframe"
+          title="Ashwin Iyer's resume"
+        />
+      </div>
+      <p className="resume-fallback">
+        PDF not displaying? <a href="/resume.pdf">Open it directly</a>.
+      </p>
     </div>
   );
 }

--- a/app/resume/resume.css
+++ b/app/resume/resume.css
@@ -1,42 +1,161 @@
+/* Resume page — header row + full-height framed PDF viewer */
+
 .resume {
-  padding: 24px;
-  width: 100vw;
-  min-width: 100%;
-  max-width: 1200px;
-  height: 100vh;
   display: flex;
   flex-direction: column;
-  box-sizing: border-box;
-  margin: 0 auto;
+  width: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 0 var(--space-lg) var(--space-lg);
 }
 
-.resumeIframe {
-  width: 100%;
-  min-width: 100%;
+/* Header row: title block + download action */
+.resume-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.resume-eyebrow {
+  margin-bottom: var(--space-xs);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.resume-title {
+  /* size/weight/tracking come from the global h1 scale */
+  line-height: 1.2;
+}
+
+/* Download button: quiet outline, brass icon detail */
+.resume-download {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 10px var(--space-md);
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.2;
+  color: var(--text-primary);
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition:
+    transform var(--transition-base),
+    border-color var(--transition-base),
+    background-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.resume-download-icon {
+  flex-shrink: 0;
+  color: var(--accent-brand, #d4a24e);
+}
+
+.resume-download:hover {
+  color: var(--text-primary);
+  background: var(--bg-card-hover);
+  border-color: var(--border-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.resume-download:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
+/* Viewer: canonical card frame, fills remaining viewport height.
+   Flex column with a flex:1 iframe (not height: 100%): percentage heights
+   are not guaranteed to resolve against a flex-grown parent when the page
+   height comes from min-height. isolation makes WebKit clip the iframe to
+   the rounded corners. */
+.resume-viewer {
+  display: flex;
+  flex-direction: column;
   flex: 1;
+  min-height: 480px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.resume-iframe {
+  flex: 1;
+  width: 100%;
   border: 0;
 }
 
-@media (max-width: 768px) {
+/* Fallback for browsers that won't render inline PDFs */
+.resume-fallback {
+  margin-top: var(--space-md);
+  font-size: 1rem;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.resume-fallback a {
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-decoration-color: var(--border-hover);
+  text-underline-offset: 3px;
+  transition:
+    color var(--transition-base),
+    text-decoration-color var(--transition-base);
+}
+
+.resume-fallback a:hover {
+  color: var(--text-primary);
+  text-decoration-color: var(--accent-brand, #d4a24e);
+}
+
+.resume-fallback a:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+@media (max-width: 640px) {
   .resume {
-    padding: 16px 12px;
-    width: 100%;
-    min-width: 100%;
-    overflow-x: hidden;
+    padding: 0 var(--space-md) var(--space-md);
   }
 
-  .resumeIframe {
-    height: 500px;
-    width: 100%;
+  .resume-header {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: var(--space-md);
+  }
+
+  .resume-title {
+    font-size: 2rem;
+  }
+
+  .resume-download {
+    align-self: stretch;
+    justify-content: center;
+  }
+
+  .resume-viewer {
+    min-height: 420px;
   }
 }
 
-@media (max-width: 480px) {
-  .resume {
-    padding: 12px 8px;
+@media (prefers-reduced-motion: reduce) {
+  .resume-download,
+  .resume-fallback a {
+    transition: none;
   }
 
-  .resumeIframe {
-    height: 400px;
+  .resume-download:hover {
+    transform: none;
   }
 }


### PR DESCRIPTION
## Summary
- Replace the bare full-page iframe on `/resume` with a proper page: eyebrow label + h1 title and a quiet outlined **Download PDF** button (brass icon detail, `var(--accent-brand, #d4a24e)` with static fallback) linking to `/resume.pdf`
- Frame the PDF viewer with the canonical card treatment (1px `var(--border-color)`, `var(--radius-lg)`, `overflow: hidden`), filling the remaining viewport height; the viewer is a flex column with a `flex: 1` iframe (percentage heights do not reliably resolve against a flex-grown parent in a `min-height` container), and `isolation: isolate` makes WebKit clip the iframe to the rounded corners
- Fix the `width: 100vw` horizontal-overflow bug (`width: 100%` inside the centered `main`)
- Standardize to the 640px breakpoint (header stacks, button stretches, viewer keeps a usable min-height), add `:focus-visible` brass outlines, `prefers-reduced-motion` support, and a fallback "Open it directly" link for browsers that will not render inline PDFs
- Add `/resume` page metadata (title/description); Bar nav import and rendering unchanged

## Notes for reviewers
- The iframe keeps its existing source (`ashwin-iyer1.github.io/.../Ashwin_Iyer_CV.pdf`) per the coordinator brief, while Download links `/resume.pdf` — the two copies are separately maintained and can drift; consolidating sources is a possible follow-up outside this unit's file set
- `--accent-brand` is defined in another unit's PR; all references here carry the static `#d4a24e` fallback as instructed
- `npm run lint` fails on `main` too (missing `typescript` module in node_modules — pre-existing environment issue, not introduced here); `npm run build` passes and `/resume` was verified on a dev server (HTTP 200, title, h1, download href)

🤖 Generated with [Claude Code](https://claude.com/claude-code)