### PR TITLE
Unit 2: Modernize nav bar — sticky glass header, brass active link, accessible theme toggle

### DIFF
--- a/app/components/Bar.css
+++ b/app/components/Bar.css
@@ -1,58 +1,78 @@
 /* Navigation Bar */
 .Bar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 0;
+  gap: var(--space-md);
+  padding: var(--space-md) 0;
   width: 100%;
   border-bottom: 1px solid var(--border-color);
   margin-bottom: var(--space-xl);
+  background: var(--bg-primary);
+  background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .logo {
   font-family: "Caveat", cursive;
   font-weight: 700;
   font-size: 2rem;
+  line-height: 1.2;
   color: var(--logo-color);
   text-decoration: none;
-  transition: opacity var(--transition-fast);
+  transition: opacity var(--transition-base);
   letter-spacing: -0.01em;
+  border-radius: var(--radius-sm);
 }
 
 .logo:hover {
   opacity: 0.7;
 }
 
+.logo:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .nav-link {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
   color: var(--text-secondary);
-  font-size: 1.1rem;
+  font-size: 0.9375rem;
   font-weight: 500;
   text-decoration: none;
-  padding: 8px 16px;
+  padding: 8px 14px;
   border-radius: var(--radius-sm);
-  transition: color var(--transition-fast);
-  letter-spacing: 0.01em;
+  transition: color var(--transition-base);
+  letter-spacing: 0.02em;
 }
 
 .nav-link:hover {
   color: var(--text-primary);
 }
 
+.nav-link:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
 .nav-link-active {
-  color: var(--text-primary);
+  color: var(--accent-brand, #d4a24e);
   font-weight: 600;
 }
 
 .nav-link-active:hover {
-  color: var(--text-primary);
+  color: var(--accent-brand, #d4a24e);
 }
 
 /* Theme Toggle */
@@ -62,13 +82,14 @@
   justify-content: center;
   width: 36px;
   height: 36px;
+  flex-shrink: 0;
   background: transparent;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color var(--transition-fast), border-color var(--transition-fast);
-  margin-left: 8px;
+  transition: color var(--transition-base), border-color var(--transition-base);
+  margin-left: var(--space-sm);
   padding: 0;
 }
 
@@ -77,23 +98,76 @@
   border-color: var(--border-hover);
 }
 
-@media (max-width: 767px) {
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
+.theme-toggle-icon {
+  position: relative;
+  display: block;
+  width: 18px;
+  height: 18px;
+}
+
+.theme-toggle-icon svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transition: opacity var(--transition-base);
+}
+
+/* Icon visibility follows [data-theme] on <html> (set before paint by the
+   inline script in layout.js) so the correct icon shows on first paint. */
+.theme-toggle-icon .icon-sun {
+  opacity: 1;
+}
+
+.theme-toggle-icon .icon-moon {
+  opacity: 0;
+}
+
+[data-theme="light"] .theme-toggle-icon .icon-sun {
+  opacity: 0;
+}
+
+[data-theme="light"] .theme-toggle-icon .icon-moon {
+  opacity: 1;
+}
+
+/* Compact layout on small screens: stays a single row, wrapping
+   gracefully on ultra-narrow viewports instead of clipping. */
+@media (max-width: 640px) {
   .Bar {
-    flex-direction: column;
-    gap: 12px;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
     padding: 12px 0;
   }
 
   .logo {
-    font-size: 1.8rem;
+    font-size: 1.5rem;
   }
 
   .nav-links {
+    flex-wrap: wrap;
     gap: 2px;
   }
 
   .nav-link {
-    font-size: 0.85rem;
-    padding: 6px 12px;
+    font-size: 0.875rem;
+    padding: 6px 10px;
+  }
+
+  .theme-toggle {
+    margin-left: var(--space-xs);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .logo,
+  .nav-link,
+  .theme-toggle,
+  .theme-toggle-icon svg {
+    transition: none;
   }
 }

--- a/app/components/Bar.css
+++ b/app/components/Bar.css
@@ -46,7 +46,7 @@
 }
 
 .nav-link {
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  /* font-family inherits from body (self-hosted Inter via next/font) */
   color: var(--text-secondary);
   font-size: 0.9375rem;
   font-weight: 500;

--- a/app/components/Bar.js
+++ b/app/components/Bar.js
@@ -15,7 +15,7 @@ export default function Bar() {
   ];
 
   return (
-    <nav className="Bar">
+    <nav className="Bar" aria-label="Primary">
       <Link href="/" className="logo">
         Ashwin Iyer
       </Link>
@@ -24,6 +24,7 @@ export default function Bar() {
           <Link
             key={href}
             href={href}
+            aria-current={pathname === href ? "page" : undefined}
             className={`nav-link ${pathname === href ? "nav-link-active" : ""}`}
           >
             {label}

--- a/app/components/ThemeToggle.js
+++ b/app/components/ThemeToggle.js
@@ -1,6 +1,17 @@
 "use client";
 import React, { useEffect, useState } from "react";
 
+const iconProps = {
+  width: "18",
+  height: "18",
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: "1.5",
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+};
+
 export default function ThemeToggle() {
   const [theme, setTheme] = useState("dark");
 
@@ -17,14 +28,20 @@ export default function ThemeToggle() {
     localStorage.setItem("theme", next);
   };
 
+  const isDark = theme === "dark";
+
   return (
     <button
+      type="button"
       onClick={toggle}
-      aria-label="Toggle theme"
+      aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
       className="theme-toggle"
     >
-      {theme === "dark" ? (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      {/* Icon visibility is driven by [data-theme] in Bar.css so the correct
+          icon paints immediately (the inline script in layout.js sets the
+          attribute before hydration), with a subtle cross-fade on toggle. */}
+      <span className="theme-toggle-icon" aria-hidden="true">
+        <svg className="icon-sun" {...iconProps}>
           <circle cx="12" cy="12" r="5" />
           <line x1="12" y1="1" x2="12" y2="3" />
           <line x1="12" y1="21" x2="12" y2="23" />
@@ -35,11 +52,10 @@ export default function ThemeToggle() {
           <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
           <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
         </svg>
-      ) : (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="icon-moon" {...iconProps}>
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
-      )}
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary

Unit 2 of the portfolio modernization batch. Touches only its owned files: `app/components/Bar.js`, `app/components/Bar.css`, `app/components/ThemeToggle.js`.

### Nav bar (`Bar.js` / `Bar.css`)
- **Sticky glass header**: `position: sticky; top: 0; z-index: 100` with a translucent background (`color-mix` over `--bg-primary`, opaque token fallback for older browsers) and `backdrop-filter: blur(12px)` (+ `-webkit-` prefix). Works in both themes.
- **Brass active link**: active nav item uses `var(--accent-brand, #d4a24e)` (static fallback so this PR stands alone before the tokens PR lands) plus weight 600 as a non-color cue. `aria-current="page"` and `aria-label="Primary"` added; exported API/usage unchanged.
- **Refined type**: links at 0.9375rem / 500 / 0.02em tracking; consistent brass `:focus-visible` rings on logo, links, and toggle. Logo keeps the Caveat family.
- **Mobile**: old 767px stacked layout replaced with the canonical 640px breakpoint — compact single row (smaller logo, tighter link padding) that wraps gracefully on ultra-narrow viewports instead of clipping.
- `prefers-reduced-motion` disables nav transitions.

### Theme toggle (`ThemeToggle.js`)
- Proper button semantics (`type="button"`), dynamic `aria-label` ("Switch to light/dark theme"), visible focus ring.
- Subtle opacity-only icon cross-fade (no rotation/scale). Icon visibility is now driven by `[data-theme]` CSS — since layout.js's inline script sets the attribute before paint, stored-light visitors see the correct moon icon on first paint (fixes a wrong-icon flash the old conditional render had).
- Behavior unchanged: toggles `data-theme` on `<html>`, persists to localStorage under the `"theme"` key.

## Notes for the coordinator (out of this unit's file scope)
1. **Sticky is currently inert on most pages**: `overflow-x: hidden` on `main` (globals.css) and on the page wrappers (`.Home`, `.Project1`, `.About`) makes them scroll containers, so the bar degrades to static there (it can stick on blog pages). Switching those to `overflow-x: clip` (or removing them) in the globals/page units will activate sticky with no change needed here.
2. **Light-theme brass contrast**: the `#d4a24e` fallback is ~2.1:1 against the light `--bg-primary`. Recommend the tokens PR define a darker brass for `[data-theme="light"]` (e.g. ~#a5761f) so focus rings and the active link meet 3:1 in light mode.
3. If sticky is activated later, the page wrappers' horizontal padding will leave small uncovered gutters beside the bar — worth aligning in the page units.

## Testing
- `npm run build` passes (lint is broken pre-existing on main: ESLint can't resolve `typescript` in node_modules; unrelated to this change).
- Dev server e2e on :3102 — `/` and `/projects` return 200; rendered HTML contains Home/Projects/About labels, `aria-current="page"` on the active link, `type="button"` and both theme icons on the toggle.
- Multi-angle code review run; findings fixed (icon flash, ultra-narrow wrap, active-link hierarchy) or documented above (sticky ancestors, light-theme brass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)