### PR TITLE
Modernize misc projects carousel and coding-time widget (unit 13)

### DIFF
--- a/app/components/GetTime.module.css
+++ b/app/components/GetTime.module.css
@@ -1,84 +1,132 @@
-/* GetTime Component Styles */
+/* Current coding time widget */
 
-.Time {
+.timeCard {
   width: 100%;
   background: var(--bg-card);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  overflow: hidden;
-  transition: all var(--transition-slow);
-  position: relative;
+  padding: var(--space-lg);
+  transition:
+    transform var(--transition-base),
+    border-color var(--transition-base),
+    box-shadow var(--transition-base),
+    background-color var(--transition-base);
 }
 
-.Time::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: var(--border-hover);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-}
-
-.Time:hover {
+.timeCard:hover {
+  transform: translateY(-2px);
   border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
+  background: var(--bg-card-hover);
 }
 
-.Working {
-  padding: var(--space-lg) var(--space-lg);
-  text-align: center;
-}
-
-.Working h2 {
+/* Widget label with live indicator */
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin: 0 0 var(--space-md);
   color: var(--text-secondary);
-  font-size: 0.85rem;
-  margin-bottom: 8px;
+  font-size: 0.8125rem;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.02em;
 }
 
-.Working p {
+.label::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-brand, #d4a24e);
+  flex-shrink: 0;
+}
+
+/* Stat rows */
+.stats {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.statRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin: 0;
+  font-size: 1rem;
+}
+
+.statLabel {
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+}
+
+.statValue {
   color: var(--text-primary);
-  font-size: 0.95rem;
-  font-weight: 500;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
-@media (max-width: 767px) {
-  .Working {
-    padding: 12px var(--space-md);
-  }
+/* Source attribution */
+.meta {
+  margin: var(--space-md) 0 0;
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+}
 
-  .Working h2 {
-    font-size: 0.8rem;
-  }
+.meta a {
+  color: var(--accent-primary);
+  transition: color var(--transition-base);
+}
 
-  .Working p {
-    font-size: 0.9rem;
-  }
+.meta a:hover {
+  color: var(--accent-secondary);
+}
 
-  .Time {
+.meta a:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
+/* Loading state */
+.loadingStats .statValue {
+  color: var(--text-secondary);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@media (max-width: 1024px) {
+  .timeCard {
+    max-width: 320px;
     margin: 0 auto;
-    max-width: 300px;
-    width: 100%;
   }
 }
 
-@media (max-width: 480px) {
-  .Working {
-    padding: 10px 12px;
+@media (prefers-reduced-motion: reduce) {
+  .timeCard {
+    transition: none;
   }
 
-  .Working h2 {
-    font-size: 0.75rem;
+  .timeCard:hover {
+    transform: none;
   }
 
-  .Working p {
-    font-size: 0.85rem;
-  }
-
-  .Time {
-    max-width: 280px;
+  .loadingStats .statValue {
+    animation: none;
   }
 }

--- a/app/components/GetTimeWrapper.js
+++ b/app/components/GetTimeWrapper.js
@@ -5,11 +5,9 @@ import styles from "./GetTime.module.css";
 
 export default function GetTimeWrapper() {
   return (
-    <div className={styles.Time}>
-      <div className={styles.Working}>
-        <h2>Current coding time</h2>
-        <GetTime />
-      </div>
-    </div>
+    <section className={styles.timeCard}>
+      <h2 className={styles.label}>Current coding time</h2>
+      <GetTime />
+    </section>
   );
 }

--- a/app/components/MiscProj.js
+++ b/app/components/MiscProj.js
@@ -3,33 +3,51 @@
 import React, { useState, useEffect } from "react";
 import styles from "./MiscProj.module.css";
 
+const videos = [
+  {
+    src: "https://www.youtube.com/embed/kebgQLcctb4",
+    title: "Financial Derivatives in Alternative Markets (Polymarket)"
+  },
+  {
+    src: "https://www.youtube.com/embed/PjFANvMtrqM",
+    title: "7110A | VEX Over Under | Short Reveal"
+  },
+  {
+    src: "https://www.youtube.com/embed/_XEaRUrlE2c",
+    title: "The Wolf of Skyblock"
+  },
+  {
+    src: "https://www.youtube.com/embed/NANJDR9GeSE",
+    title: "White Mountain National Forest Vlog"
+  },
+  {
+    src: "https://www.youtube.com/embed/HEUlochQ9fc",
+    title: "Puerto Rico Vlog"
+  }
+];
+
+const pad = (n) => String(n).padStart(2, "0");
+
+// Shimmer skeleton shown while an iframe loads
+const VideoSkeleton = () => (
+  <div className={styles.skeleton}>
+    <div className={styles.skeletonPlayButton}></div>
+  </div>
+);
+
+const Caption = ({ index }) => (
+  <div className={styles.caption}>
+    <p className={styles.captionMeta}>
+      {pad(index + 1)} / {pad(videos.length)}
+    </p>
+    <h3 className={styles.captionTitle}>{videos[index].title}</h3>
+  </div>
+);
+
 export default function MiscProj() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isClient, setIsClient] = useState(false);
   const [loadedVideos, setLoadedVideos] = useState({});
-
-  const videos = [
-    {
-      src: "https://www.youtube.com/embed/kebgQLcctb4",
-      title: "Financial Derivatives in Alternative Markets (Polymarket)"
-    },
-    {
-      src: "https://www.youtube.com/embed/PjFANvMtrqM",
-      title: "7110A | VEX Over Under | Short Reveal"
-    },
-    {
-      src: "https://www.youtube.com/embed/_XEaRUrlE2c",
-      title: "The Wolf of Skyblock"
-    },
-    {
-      src: "https://www.youtube.com/embed/NANJDR9GeSE",
-      title: "White Mountain National Forest Vlog"
-    },
-    {
-      src: "https://www.youtube.com/embed/HEUlochQ9fc",
-      title: "Puerto Rico Vlog"
-    }
-  ];
 
   useEffect(() => {
     setIsClient(true);
@@ -40,13 +58,13 @@ export default function MiscProj() {
   };
 
   const nextSlide = () => {
-    setCurrentIndex((prevIndex) => 
+    setCurrentIndex((prevIndex) =>
       prevIndex === videos.length - 1 ? 0 : prevIndex + 1
     );
   };
 
   const prevSlide = () => {
-    setCurrentIndex((prevIndex) => 
+    setCurrentIndex((prevIndex) =>
       prevIndex === 0 ? videos.length - 1 : prevIndex - 1
     );
   };
@@ -58,15 +76,6 @@ export default function MiscProj() {
   const prevIndex = currentIndex === 0 ? videos.length - 1 : currentIndex - 1;
   const nextIndex = currentIndex === videos.length - 1 ? 0 : currentIndex + 1;
 
-  // Skeleton loader component
-  const VideoSkeleton = ({ isMain = false, className = "" }) => (
-    <div className={`${styles.skeleton} ${isMain ? styles.skeletonMain : styles.skeletonSide} ${className}`}>
-      <div className={styles.skeletonContent}>
-        <div className={styles.skeletonPlayButton}></div>
-      </div>
-    </div>
-  );
-
   // Prevent hydration mismatch by only rendering interactive elements on client
   if (!isClient) {
     return (
@@ -75,9 +84,12 @@ export default function MiscProj() {
           <button className={styles.carouselButton} aria-label="Previous video" disabled>
             ‹
           </button>
-          
-          <div className={styles.videoWrapper}>
-            <VideoSkeleton isMain />
+
+          <div className={styles.videoCard}>
+            <div className={styles.media}>
+              <VideoSkeleton />
+            </div>
+            <Caption index={0} />
           </div>
 
           <button className={styles.carouselButton} aria-label="Next video" disabled>
@@ -105,52 +117,60 @@ export default function MiscProj() {
         <button className={styles.carouselButton} onClick={prevSlide} aria-label="Previous video">
           ‹
         </button>
-        
+
         <div className={styles.sideVideo} onClick={prevSlide}>
-          {!loadedVideos[prevIndex] && <VideoSkeleton className={styles.skeletonSide} />}
-          <iframe
-            src={videos[prevIndex].src}
-            title={videos[prevIndex].title}
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerPolicy="strict-origin-when-cross-origin"
-            allowFullScreen={false}
-            className={styles.previewIframe}
-            onLoad={() => handleIframeLoad(prevIndex)}
-            style={{ opacity: loadedVideos[prevIndex] ? 1 : 0 }}
-          ></iframe>
-          <div className={styles.overlay}></div>
+          <div className={styles.media}>
+            {!loadedVideos[prevIndex] && <VideoSkeleton />}
+            <iframe
+              src={videos[prevIndex].src}
+              title={videos[prevIndex].title}
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allowFullScreen={false}
+              className={styles.previewIframe}
+              onLoad={() => handleIframeLoad(prevIndex)}
+              style={{ opacity: loadedVideos[prevIndex] ? 1 : 0 }}
+            ></iframe>
+            <div className={styles.overlay}></div>
+          </div>
         </div>
 
-        <div className={styles.videoWrapper}>
-          {!loadedVideos[currentIndex] && <VideoSkeleton isMain />}
-          <iframe
-            key={currentIndex}
-            src={videos[currentIndex].src}
-            title={videos[currentIndex].title}
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerPolicy="strict-origin-when-cross-origin"
-            allowFullScreen
-            onLoad={() => handleIframeLoad(currentIndex)}
-            style={{ opacity: loadedVideos[currentIndex] ? 1 : 0, transition: 'opacity 0.3s ease' }}
-          ></iframe>
+        <div className={styles.videoCard}>
+          <div className={styles.media}>
+            {!loadedVideos[currentIndex] && <VideoSkeleton />}
+            <iframe
+              key={currentIndex}
+              src={videos[currentIndex].src}
+              title={videos[currentIndex].title}
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allowFullScreen
+              className={styles.mainIframe}
+              onLoad={() => handleIframeLoad(currentIndex)}
+              style={{ opacity: loadedVideos[currentIndex] ? 1 : 0 }}
+            ></iframe>
+          </div>
+          <Caption index={currentIndex} />
         </div>
 
         <div className={styles.sideVideo} onClick={nextSlide}>
-          {!loadedVideos[nextIndex] && <VideoSkeleton className={styles.skeletonSide} />}
-          <iframe
-            src={videos[nextIndex].src}
-            title={videos[nextIndex].title}
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerPolicy="strict-origin-when-cross-origin"
-            allowFullScreen={false}
-            className={styles.previewIframe}
-            onLoad={() => handleIframeLoad(nextIndex)}
-            style={{ opacity: loadedVideos[nextIndex] ? 1 : 0 }}
-          ></iframe>
-          <div className={styles.overlay}></div>
+          <div className={styles.media}>
+            {!loadedVideos[nextIndex] && <VideoSkeleton />}
+            <iframe
+              src={videos[nextIndex].src}
+              title={videos[nextIndex].title}
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allowFullScreen={false}
+              className={styles.previewIframe}
+              onLoad={() => handleIframeLoad(nextIndex)}
+              style={{ opacity: loadedVideos[nextIndex] ? 1 : 0 }}
+            ></iframe>
+            <div className={styles.overlay}></div>
+          </div>
         </div>
 
         <button className={styles.carouselButton} onClick={nextSlide} aria-label="Next video">

--- a/app/components/MiscProj.module.css
+++ b/app/components/MiscProj.module.css
@@ -1,172 +1,232 @@
+/* Miscellaneous projects carousel */
+
 .carouselContainer {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 20px;
-  max-width: 100%;
+  gap: var(--space-lg);
   width: 100%;
-  padding: 20px;
-  overflow: hidden;
+  /* breathing room so hover lift + shadow aren't clipped by ancestor overflow:hidden */
+  padding: var(--space-md);
 }
 
 .carousel {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 20px;
+  gap: var(--space-md);
   width: 100%;
-  max-width: 1400px;
+}
+
+/* Featured video — canonical card */
+.videoCard {
+  flex: 1 1 560px;
+  min-width: 0;
+  max-width: 608px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  transition:
+    transform var(--transition-base),
+    border-color var(--transition-base),
+    box-shadow var(--transition-base),
+    background-color var(--transition-base);
+}
+
+.videoCard:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
+  background: var(--bg-card-hover);
+}
+
+/* Media frame — consistent 16:9 aspect, rounded corners */
+.media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
-.videoWrapper {
-  flex: 0 0 auto;
+.media iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.mainIframe {
+  transition: opacity var(--transition-base);
+}
+
+.previewIframe {
+  pointer-events: none;
+  transition: opacity var(--transition-base);
+}
+
+/* Caption below the featured video */
+.caption {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 2;
-  position: relative;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-top: var(--space-md);
+  text-align: left;
 }
 
-.videoWrapper iframe {
-  width: 640px;
-  height: 360px;
-  border-radius: 8px;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
-  transition: transform 0.3s ease;
+.captionMeta {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
 }
 
+.captionTitle {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.4;
+  color: var(--text-primary);
+}
+
+/* Side previews */
 .sideVideo {
-  flex: 0 0 auto;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
+  flex: 1 1 180px;
+  min-width: 0;
+  max-width: 200px;
   position: relative;
-  opacity: 0.5;
-  transition: all 0.3s ease;
-  transform: scale(0.75);
+  cursor: pointer;
+  opacity: 0.55;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base),
+    border-color var(--transition-base),
+    box-shadow var(--transition-base);
 }
 
 .sideVideo:hover {
-  opacity: 0.8;
-  transform: scale(0.8);
+  opacity: 0.9;
+  transform: translateY(-2px);
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
 }
 
-.sideVideo iframe {
-  width: 480px;
-  height: 270px;
-  border-radius: 8px;
-  pointer-events: none;
+.sideVideo .media {
+  border-radius: 0;
 }
 
 .overlay {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 8px;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
   pointer-events: none;
 }
 
+/* Prev / next controls */
 .carouselButton {
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-color);
-  font-size: 36px;
-  cursor: pointer;
-  padding: 10px 20px;
-  border-radius: 50%;
-  transition: all 0.3s ease;
-  width: 52px;
-  height: 52px;
+  flex: 0 0 44px;
+  width: 44px;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
   user-select: none;
+  transition:
+    background-color var(--transition-base),
+    border-color var(--transition-base),
+    color var(--transition-base);
 }
 
-.carouselButton:hover {
-  background: rgba(255, 255, 255, 0.1);
+.carouselButton:hover:not(:disabled) {
+  background: var(--bg-card-hover);
   border-color: var(--border-hover);
   color: var(--text-primary);
-  transform: scale(1.05);
 }
 
-.carouselButton:active {
-  transform: scale(0.95);
+.carouselButton:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
+.carouselButton:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
+/* Position indicators */
 .indicators {
   display: flex;
-  gap: 10px;
+  gap: var(--space-sm);
   justify-content: center;
-  margin-top: 20px;
 }
 
 .indicator {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.2);
+  width: 8px;
+  height: 8px;
+  padding: 0;
   border: none;
+  border-radius: 999px;
+  background: var(--border-hover);
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition:
+    background-color var(--transition-base),
+    width var(--transition-base);
 }
 
-.indicator:hover {
-  background: rgba(255, 255, 255, 0.4);
-  transform: scale(1.2);
+.indicator:hover:not(:disabled) {
+  background: var(--text-secondary);
 }
 
 .indicator.active {
-  background: var(--text-primary);
-  width: 12px;
-  height: 12px;
+  width: 24px;
+  background: var(--accent-brand, #d4a24e);
 }
 
-/* Skeleton Loader Styles */
+.indicator:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
+/* Skeleton loader (shimmer aligned to theme tokens) */
 .skeleton {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(90deg, var(--bg-secondary) 25%, var(--bg-card-hover) 50%, var(--bg-secondary) 75%);
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--bg-card);
+  background-image: linear-gradient(
+    90deg,
+    transparent 25%,
+    var(--border-color) 50%,
+    transparent 75%
+  );
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1;
-}
-
-.skeletonMain {
-  width: 640px;
-  height: 360px;
-}
-
-.skeletonSide {
-  width: 480px;
-  height: 270px;
-  transform: scale(0.75);
-}
-
-.skeletonContent {
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .skeletonPlayButton {
-  width: 80px;
-  height: 80px;
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
-  background: rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--border-hover);
+  background: var(--bg-card);
   position: relative;
 }
 
@@ -178,9 +238,9 @@
   transform: translate(-40%, -50%);
   width: 0;
   height: 0;
-  border-left: 25px solid rgba(0, 0, 0, 0.15);
-  border-top: 15px solid transparent;
-  border-bottom: 15px solid transparent;
+  border-left: 18px solid var(--border-hover);
+  border-top: 11px solid transparent;
+  border-bottom: 11px solid transparent;
 }
 
 @keyframes shimmer {
@@ -192,138 +252,56 @@
   }
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1024px) {
   .sideVideo {
-    transform: scale(0.65);
-  }
-
-  .sideVideo:hover {
-    transform: scale(0.7);
-  }
-
-  .sideVideo iframe {
-    width: 400px;
-    height: 225px;
-  }
-
-  .videoWrapper iframe {
-    width: 560px;
-    height: 315px;
-  }
-
-  .skeletonMain {
-    width: 560px;
-    height: 315px;
-  }
-
-  .skeletonSide {
-    width: 400px;
-    height: 225px;
-    transform: scale(0.65);
-  }
-}
-
-@media (max-width: 1080px) {
-  .carousel {
-    gap: 10px;
-    padding: 0 8px;
-  }
-
-  .sideVideo {
-    display: none;
-  }
-
-  .videoWrapper iframe {
-    width: calc(100vw - 120px);
-    max-width: 560px;
-    height: calc((100vw - 120px) * 9 / 16);
-    max-height: 315px;
-  }
-
-  .carouselButton {
-    font-size: 36px;
-    width: 50px;
-    height: 50px;
-  }
-
-  .skeletonMain {
-    width: calc(100vw - 120px);
-    max-width: 560px;
-    height: calc((100vw - 120px) * 9 / 16);
-    max-height: 315px;
-  }
-
-  .skeletonSide {
     display: none;
   }
 }
 
-@media (max-width: 767px) {
-  .carouselContainer {
-    padding: 16px 8px;
-  }
-
+@media (max-width: 640px) {
   .carousel {
-    gap: 8px;
-    padding: 0;
+    gap: var(--space-sm);
   }
 
-  .videoWrapper iframe {
-    width: calc(100vw - 120px);
-    max-width: calc(100vw - 120px);
-    height: calc((100vw - 120px) * 9 / 16);
+  .videoCard {
+    padding: var(--space-md);
   }
 
   .carouselButton {
-    font-size: 24px;
+    flex-basis: 36px;
     width: 36px;
     height: 36px;
-    padding: 4px 8px;
-  }
-
-  .indicators {
-    gap: 6px;
-    margin-top: 16px;
-  }
-
-  .skeletonMain {
-    width: calc(100vw - 120px);
-    max-width: calc(100vw - 120px);
-    height: calc((100vw - 120px) * 9 / 16);
+    font-size: 1.25rem;
   }
 
   .skeletonPlayButton {
-    width: 60px;
-    height: 60px;
+    width: 48px;
+    height: 48px;
   }
 
   .skeletonPlayButton::after {
-    border-left: 20px solid rgba(0, 0, 0, 0.15);
-    border-top: 12px solid transparent;
-    border-bottom: 12px solid transparent;
-  }
-
-  .indicator {
-    width: 8px;
-    height: 8px;
-  }
-
-  .indicator.active {
-    width: 10px;
-    height: 10px;
+    border-left: 14px solid var(--border-hover);
+    border-top: 9px solid transparent;
+    border-bottom: 9px solid transparent;
   }
 }
 
-@media (max-width: 480px) {
-  .videoWrapper iframe {
-    width: calc(100vw - 100px);
-    max-width: calc(100vw - 100px);
-    height: calc((100vw - 100px) * 9 / 16);
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
   }
 
-  .carouselButton {
-    font-size: 20px;
-    width: 32px;
-    height: 32px;
+  .videoCard,
+  .sideVideo,
+  .carouselButton,
+  .indicator,
+  .mainIframe,
+  .previewIframe {
+    transition: none;
+  }
+
+  .videoCard:hover,
+  .sideVideo:hover {
+    transform: none;
   }
 }

--- a/app/components/getTime.js
+++ b/app/components/getTime.js
@@ -1,7 +1,19 @@
 "use client";
-import React, { useEffect, useState } from "react"; // Import useEffect and useState
+import React, { useEffect, useState } from "react";
+import styles from "./GetTime.module.css";
 
-export default function getTime() {
+const WAKATIME_PROFILE =
+  "https://wakatime.com/@bc413433-56e4-4dee-b14c-d8c669a8be79";
+
+// Coerce first: the API may return numeric columns as strings
+const formatHours = (seconds) => {
+  const n = Number(seconds);
+  return seconds != null && Number.isFinite(n)
+    ? `${(n / 3600).toFixed(1)} hrs`
+    : "N/A";
+};
+
+export default function GetTime() {
   const [wakatime, setWakatime] = useState([]); // State for Wakatime data
   const [loading, setLoading] = useState(true); // State for loading
 
@@ -14,9 +26,9 @@ export default function getTime() {
         if (!res.ok) {
           throw new Error("Network response was not ok");
         }
-        console.log(res);
+
         // Await the JSON response to get the Wakatime data
-        const data = await res.json(); // Make sure to await this
+        const data = await res.json();
         setWakatime(data); // Set the fetched data
       } catch (error) {
         console.error(
@@ -34,60 +46,25 @@ export default function getTime() {
     fetchWakatime(); // Call the fetch function
   }, []); // Empty dependency array to run once on mount
 
-  // Loading skeleton placeholder
-  if (loading) {
-    return (
-      <div className="wakatime skeleton"       style={{
-        color: "var(--text-primary)",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        gap: "8px",
-      }}
->
-        <p style={{ fontSize: "1em" }}>Total: N/A Hours</p>
-        <p style={{ fontSize: "1em" }}>Daily Average: N/A Hours</p>
-        <p style={{ fontSize: ".8em" }}>
-          Tracked with{" "}
-          <a
-            href="https://wakatime.com/@bc413433-56e4-4dee-b14c-d8c669a8be79"
-            target="_blank"
-            style={{
-              color: "var(--accent-primary)",
-            }}
-          >
-            Wakatime
-          </a>
-        </p>
-      </div>
-    ); // Return loading skeleton
-  }
+  const stats = Array.isArray(wakatime) ? wakatime[0] : undefined;
+
   return (
-    <div
-      className="wakatime"
-      style={{
-        color: "var(--text-primary)",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        gap: "8px",
-      }}
-    >
-      <p style={{ fontSize: "1em" }}>
-        Total: {(wakatime[0]?.total_seconds / 60 / 60).toFixed(1)} Hours
+    <div className={`${styles.stats} ${loading ? styles.loadingStats : ""}`}>
+      <p className={styles.statRow}>
+        <span className={styles.statLabel}>Total</span>
+        <span className={styles.statValue}>
+          {loading ? "—" : formatHours(stats?.total_seconds)}
+        </span>
       </p>
-      <p style={{ fontSize: "1em" }}>
-        Daily Average: {(wakatime[0]?.daily_average / 60 / 60).toFixed(1)} Hours
+      <p className={styles.statRow}>
+        <span className={styles.statLabel}>Daily average</span>
+        <span className={styles.statValue}>
+          {loading ? "—" : formatHours(stats?.daily_average)}
+        </span>
       </p>
-      <p style={{ fontSize: ".8em" }}>
+      <p className={styles.meta}>
         Tracked with{" "}
-        <a
-          href="https://wakatime.com/@bc413433-56e4-4dee-b14c-d8c669a8be79"
-          target="_blank"
-          style={{
-            color: "var(--accent-primary)",
-          }}
-        >
+        <a href={WAKATIME_PROFILE} target="_blank" rel="noopener noreferrer">
           Wakatime
         </a>
       </p>


### PR DESCRIPTION
## Summary

Unit 13 of the portfolio modernization batch — home-page widgets: the miscellaneous projects video carousel (`MiscProj`) and the Wakatime coding-time card (`getTime`/`GetTimeWrapper`).

### MiscProj carousel
- Featured video wrapped in the canonical card treatment (`--bg-card`, 1px `--border-color`, `--radius-lg`, `--space-lg` padding) with the standard hover (translateY(-2px), `--border-hover`, `--shadow-md`)
- Media uses `aspect-ratio: 16/9` with `--radius-md` corners and fluid flex sizing instead of hardcoded pixel iframes
- New caption: tabular-numeral `01 / 05` position eyebrow (0.8125rem, `--text-secondary`, 0.02em tracking) + video title at 1.125rem/600
- Side previews drop the forbidden `scale()` transforms for opacity/lift hover; hidden ≤1024px
- Buttons, indicators, and the shimmer skeleton moved off hardcoded `rgba(255,255,255,…)` onto theme tokens so both dark and light themes render correctly
- One brass detail: active indicator pill `var(--accent-brand, #d4a24e)`; brass `:focus-visible` rings on all controls
- Breakpoints standardized to exactly 640px/1024px; `prefers-reduced-motion` respected
- Skeleton/caption hoisted to module scope so onLoad re-renders no longer remount skeletons
- Lazy loading via `useIntersectionObserver` in `app/page.js` untouched

### GetTime widget
- Canonical card with uppercase meta label fronted by a small brass live-dot (its one brass detail)
- Terminal-style label/value stat rows at 1rem with `tabular-nums`; labels at 0.8125rem `--text-secondary` 0.02em
- Consistent pulsing loading state; graceful `N/A` fallback that also coerces string-typed numeric API columns (the old code silently rendered `NaN`)
- Data fetching from `/api/wakatime` unchanged

## Testing
- `npm run build` passes (17/17 pages); `npm run lint` is broken repo-wide before this change (missing `typescript` dep) — not introduced here
- Dev server smoke test on :3113 returns HTTP 200 with widget content in SSR HTML
- Only the 5 owned unit-13 files changed; splashscreen files untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)