### PR TITLE
Unit 3: Modernize home page layout and flow

### DIFF
--- a/app/landing.css
+++ b/app/landing.css
@@ -2,13 +2,15 @@
 
 /* Footer Styles */
 footer {
+  width: 100%;
   border-top: 1px solid var(--border-color);
-  color: var(--text-muted);
+  color: var(--text-secondary);
   text-align: center;
-  font-size: 0.85rem;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  letter-spacing: 0.02em;
   padding: var(--space-xl) var(--space-lg);
-  margin-top: var(--space-3xl);
-  letter-spacing: 0.01em;
+  margin-top: var(--space-4xl);
 }
 
 /* MUI Component Overrides */
@@ -34,7 +36,7 @@ footer {
 }
 
 /* Responsive Work Date Badge */
-@media (max-width: 840px) {
+@media (max-width: 1024px) {
   .work-date {
     display: inline-block;
     box-sizing: border-box;
@@ -47,16 +49,9 @@ footer {
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 640px) {
   footer {
-    font-size: 0.8rem;
     padding: var(--space-lg) var(--space-md);
-  }
-}
-
-@media (max-width: 480px) {
-  footer {
-    font-size: 0.75rem;
-    padding: var(--space-md) var(--space-sm);
+    margin-top: var(--space-3xl);
   }
 }

--- a/app/page.js
+++ b/app/page.js
@@ -75,28 +75,38 @@ export default function Home() {
         }}
       >
         <Bar />
-        <div className={styles.Container}>
-          <div className={styles.topSection}>
-            <div className={styles.basicRow}>
-              <div className={styles.basic}>
-                <h2>Junior at Northeastern University</h2>
-                <p>
-                  I am currently a junior at Northeastern University in
-                  Boston, Massachusetts, and I am interested in computer
-                  science. I am currently learning Python, Java, and TypeScript.{" "}
-                  <Link href="/about">Learn more about me!</Link>
-                </p>
-              </div>
+
+        <div className={styles.content}>
+          {/* Hero */}
+          <header className={styles.hero}>
+            <p className={styles.heroEyebrow}>
+              Junior &middot; Northeastern University &middot; Boston, MA
+            </p>
+            <h1 className={styles.heroTitle}>Ashwin Iyer</h1>
+            <p className={styles.heroLede}>
+              I&apos;m a computer science student at Northeastern, currently
+              learning Python, Java, and TypeScript.{" "}
+              <Link href="/about" className={styles.heroLink}>
+                More about me
+              </Link>
+            </p>
+            <div className={styles.heroSocial}>
               <Links />
             </div>
-            <div className={styles.workExperienceRow}>
-              <div className={styles.workExperience}>
-                <h2 id="WorkingOn">Work Experience</h2>
+          </header>
+
+          {/* Work Experience */}
+          <section className={styles.section}>
+            <h2 className="section-title" id="WorkingOn">
+              Work Experience
+            </h2>
+            <div className={styles.workRow}>
+              <div className={`glass-card ${styles.workCard}`}>
                 <WorkExperience />
               </div>
-              <div className={styles.rightColumn}>
+              <aside className={styles.workAside}>
                 <GetTimeWrapper />
-                <div className={styles.College}>
+                <div className={`glass-card ${styles.college}`}>
                   <Image
                     src={NEU}
                     id={"person"}
@@ -105,67 +115,84 @@ export default function Home() {
                     height={200}
                   />
                 </div>
+              </aside>
+            </div>
+          </section>
+
+          {/* Skills */}
+          <section className={styles.section}>
+            <h2 className="section-title">Skills</h2>
+            <Skills />
+          </section>
+
+          {/* Research */}
+          <section className={styles.section}>
+            <h2 className="section-title">Research</h2>
+            <div className={styles.researchRow}>
+              <a
+                href="/projects/NUSA Spring 26 RS - Equity Vol. Project.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`glass-card ${styles.researchLink}`}
+              >
+                NUSA Spring 26 RS — Equity Volatility Project (PDF)
+              </a>
+            </div>
+          </section>
+
+          {/* Miscellaneous Projects */}
+          <section className={styles.section}>
+            <h2 className="section-title">Miscellaneous Projects</h2>
+            <div className={styles.miscProjContainer} ref={miscProjSection}>
+              {(isMiscProjVisible || fadeIn || forceMiscProjLoad) && (
+                <Suspense fallback={<div className="loading">Loading...</div>}>
+                  <LazyMiscProj />
+                </Suspense>
+              )}
+            </div>
+          </section>
+
+          {/* Writing */}
+          <section className={styles.section}>
+            <h2 className="section-title">Writing</h2>
+            <BlogList />
+          </section>
+
+          {/* Now — live widgets */}
+          <section className={styles.section} aria-labelledby="now-title">
+            <h2 className="section-title" id="now-title">
+              Now
+            </h2>
+            <p className={styles.nowNote}>
+              Live while you read — health metrics from my Oura ring and open
+              positions on Kalshi.
+            </p>
+            <div className={styles.nowGrid}>
+              <div className={`glass-card ${styles.nowCard}`}>
+                <OuraDashboard
+                  subset={["activity", "heart_rate", "sleep", "stress"]}
+                  columns={1}
+                  chartHeight="180px"
+                  chartWidth="100%"
+                  showHeader={true}
+                  compact={true}
+                />
+              </div>
+              <div className={styles.nowCol}>
+                <KalshiPositions id="kalshi_positions" />
               </div>
             </div>
-          </div>
-        </div>
+          </section>
 
-        <div className={styles.skillsSection}>
-          <h2 className={styles.sectionTitle}>Skills</h2>
-          <Skills />
-        </div>
-
-        <div className={styles.MiscProj}>
-          <h2 className={styles.sectionTitle}>Research</h2>
-          <div className={styles.researchLinks}>
-            <a
-              href="/projects/NUSA Spring 26 RS - Equity Vol. Project.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={styles.researchLink}
-            >
-              NUSA Spring 26 RS — Equity Volatility Project (PDF)
-            </a>
-          </div>
-          <h2 className={styles.sectionTitle}>Miscellaneous Projects</h2>
-          <div className={styles.MiscProjContainer} ref={miscProjSection}>
-            {(isMiscProjVisible || fadeIn || forceMiscProjLoad) && (
-              <Suspense fallback={<div className="loading">Loading...</div>}>
-                <LazyMiscProj />
-              </Suspense>
-            )}
-          </div>
-          <h2 className={styles.sectionTitle}>My Blogs</h2>
-          <BlogList />
-        </div>
-
-        <div className={styles.dashboardRow}>
-          <div className={styles.dashboardColumn}>
-            <h2 className={styles.sectionTitle}>Live Health Stats</h2>
-            <div className={styles.dashboardCard}>
-              <OuraDashboard
-                subset={["activity", "heart_rate", "sleep", "stress"]}
-                columns={1}
-                chartHeight="180px"
-                chartWidth="100%"
-                showHeader={true}
-                compact={true}
-              />
-            </div>
-          </div>
-
-          <div className={styles.dashboardColumn}>
-            <KalshiPositions id="kalshi_positions" />
-          </div>
-        </div>
-
-        <div className={styles.Contact}>
-          <h2 className={styles.sectionTitle}>Contact Me</h2>
-          <Contact />
-          <p>
-            Email:{" "}
-            <a href="mailto:ashwiniyer06@gmail.com">ashwiniyer06@gmail.com</a>
-          </p>
+          {/* Contact */}
+          <section className={styles.section}>
+            <h2 className="section-title">Contact</h2>
+            <Contact />
+            <p className={styles.contactEmail}>
+              Email:{" "}
+              <a href="mailto:ashwiniyer06@gmail.com">ashwiniyer06@gmail.com</a>
+            </p>
+          </section>
         </div>
       </div>
     </>

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -4,334 +4,299 @@
   text-align: left;
   max-width: 1200px;
   width: 100%;
-  padding: var(--space-lg);
-  overflow-x: hidden;
+  /* `clip` (not `hidden`) so the sticky nav keeps working — an overflow-x:
+     hidden ancestor would turn this wrapper into a scroll container. */
+  overflow-x: clip;
 }
 
-/* Hero Section */
-.Container {
-  margin-top: var(--space-lg);
+/* Page gutter lives below the nav so the Bar spans the full row. */
+.content {
+  padding: 0 var(--space-lg);
 }
 
-.topSection {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
+/* ---------------------------------------------------------------------------
+   Section rhythm: 96px between sections on desktop, 64px below 640px.
+   Title-to-content spacing comes from the global .section-title utility.
+--------------------------------------------------------------------------- */
+.section {
+  margin-top: var(--space-4xl);
   width: 100%;
 }
 
-.basicRow {
+/* ---------------------------------------------------------------------------
+   Hero
+--------------------------------------------------------------------------- */
+.hero {
+  margin-top: var(--space-3xl);
   display: flex;
-  flex-direction: row;
-  gap: var(--space-lg);
-  align-items: stretch;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-md);
 }
 
-.basicRow .basic {
-  flex: 0 0 calc(75% - 12px);
+.heroEyebrow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
 }
 
-.basicRow > *:last-child {
-  flex: 0 0 calc(25% - 12px);
+.heroEyebrow::before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 1px;
+  background: var(--accent-brand, #d4a24e);
 }
 
-.basic {
-  background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  padding: var(--space-xl);
-  border: 1px solid var(--border-color);
-  transition: border-color var(--transition-slow);
-}
-
-.basic:hover {
-  border-color: var(--border-hover);
-}
-
-.basic h2 {
-  color: var(--text-primary);
-  font-size: 1.5rem;
-  margin-bottom: 12px;
+.heroTitle {
+  margin: 0;
+  font-size: 2.5rem;
   font-weight: 600;
   letter-spacing: -0.02em;
-}
-
-.basic p {
-  color: var(--text-secondary);
-  line-height: 1.7;
-  font-size: 0.95rem;
-}
-
-.basic p a {
-  color: var(--accent-primary);
-  text-decoration: none;
-  font-weight: 500;
-  transition: color var(--transition-fast);
-}
-
-.basic p a:hover {
-  color: var(--accent-secondary);
-}
-
-/* Work Experience Row */
-.workExperienceRow {
-  display: flex;
-  flex-direction: row;
-  gap: var(--space-lg);
-  align-items: stretch;
-}
-
-.workExperienceRow .workExperience {
-  flex: 0 0 calc(75% - 12px);
-}
-
-.rightColumn {
-  flex: 0 0 calc(25% - 12px);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
-  min-height: 100%;
-}
-
-.workExperience {
-  background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  padding: var(--space-xl);
-  border: 1px solid var(--border-color);
-  display: flex;
-  flex-direction: column;
-  transition: border-color var(--transition-slow);
-}
-
-.workExperience:hover {
-  border-color: var(--border-hover);
-}
-
-.workExperience h2 {
+  line-height: 1.2;
   color: var(--text-primary);
-  font-size: 1.5rem;
-  margin-bottom: var(--space-md);
-  font-weight: 600;
 }
 
-/* College Image */
-.College {
+.heroLede {
+  margin: 0;
+  max-width: 65ch;
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+.heroLink {
+  color: var(--text-primary);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-color: var(--border-hover);
+  text-underline-offset: 3px;
+  transition: color var(--transition-fast),
+    text-decoration-color var(--transition-fast);
+}
+
+.heroLink:hover {
+  color: var(--text-primary);
+  text-decoration-color: var(--accent-brand, #d4a24e);
+}
+
+/* Shared brass focus ring for interactive elements on this page */
+.heroLink:focus-visible,
+a.researchLink:focus-visible,
+.contactEmail a:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+}
+
+.heroLink:focus-visible,
+.contactEmail a:focus-visible {
+  border-radius: var(--radius-sm);
+}
+
+.heroSocial {
+  margin-top: var(--space-md);
+  width: 100%;
+  max-width: 360px;
+}
+
+/* ---------------------------------------------------------------------------
+   Work Experience
+--------------------------------------------------------------------------- */
+.workRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-lg);
+  align-items: start;
+}
+
+.workCard {
+  padding: var(--space-lg);
+}
+
+.workAside {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-lg);
+  align-items: start;
+}
+
+.college {
   padding: var(--space-md);
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-color);
-  transition: border-color var(--transition-slow);
 }
 
-.College:hover {
-  border-color: var(--border-hover);
-}
-
-.College img {
+.college img {
   max-height: 140px;
+  width: auto;
   border-radius: var(--radius-sm);
 }
 
-/* Skills Section */
-.skillsSection {
-  margin-top: var(--space-3xl);
-}
-
-.sectionTitle {
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  text-align: center;
-  margin-bottom: var(--space-xl);
-  letter-spacing: -0.02em;
-}
-
-/* Research Links */
-.researchLinks {
+/* ---------------------------------------------------------------------------
+   Research
+--------------------------------------------------------------------------- */
+.researchRow {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-  align-items: center;
-  margin-bottom: var(--space-2xl);
+  justify-content: center;
 }
 
-.researchLink {
-  display: inline-block;
-  background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
+/* `a.` prefix keeps these declarations ahead of the composed .glass-card
+   utility (which sets `transition: all`) regardless of stylesheet order. */
+a.researchLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
   padding: var(--space-md) var(--space-lg);
-  color: var(--accent-primary);
+  color: var(--text-primary);
   text-decoration: none;
   font-weight: 500;
-  font-size: 0.95rem;
-  transition: border-color var(--transition-slow), color var(--transition-fast);
-}
-
-.researchLink:hover {
-  border-color: var(--border-hover);
-  color: var(--accent-secondary);
-}
-
-/* Misc Projects */
-.MiscProj {
-  margin-top: var(--space-3xl);
-  overflow: hidden;
-  width: 100%;
-}
-
-.MiscProj h2 {
-  margin-bottom: var(--space-lg);
-}
-
-.MiscProjContainer {
-  margin-bottom: var(--space-2xl);
-  width: 100%;
-  max-width: 1200px;
-  min-height: 400px;
-  margin-left: auto;
-  margin-right: auto;
-  overflow: hidden;
-}
-
-/* Dashboard Row */
-.dashboardRow {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: center;
-  width: 100%;
-  gap: var(--space-xl);
-  flex-wrap: wrap;
-  padding: 0 var(--space-md);
-  max-width: 1400px;
-  margin: var(--space-2xl) auto 0;
-}
-
-.dashboardColumn {
-  flex: 1;
-  min-width: 320px;
-}
-
-.dashboardCard {
-  background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  transition: border-color var(--transition-slow);
-}
-
-.dashboardCard:hover {
-  border-color: var(--border-hover);
-}
-
-/* Contact Section */
-.Contact {
-  margin-top: var(--space-3xl);
-  padding-bottom: var(--space-xl);
-}
-
-.Contact h2 {
-  margin-bottom: var(--space-lg);
-}
-
-.Contact p {
-  color: var(--text-secondary);
+  font-size: 1rem;
   text-align: center;
-  font-size: 0.95rem;
+  transition: transform var(--transition-base),
+    border-color var(--transition-base), box-shadow var(--transition-base),
+    background var(--transition-base);
 }
 
-.Contact a {
-  color: var(--accent-primary);
-  text-decoration: none;
+a.researchLink:hover {
+  color: var(--text-primary);
+  transform: translateY(-2px);
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
+}
+
+/* ---------------------------------------------------------------------------
+   Miscellaneous Projects
+--------------------------------------------------------------------------- */
+.miscProjContainer {
+  width: 100%;
+  min-height: 400px;
+  overflow: hidden;
+}
+
+/* ---------------------------------------------------------------------------
+   Now — live widgets
+--------------------------------------------------------------------------- */
+.nowNote {
+  max-width: 65ch;
+  margin: 0 auto var(--space-xl);
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.nowGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-lg);
+  align-items: start;
+}
+
+/* Layout-only: card visuals come from the global .glass-card utility */
+.nowCard {
+  overflow: hidden;
+  min-width: 0;
+}
+
+.nowCol {
+  min-width: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   Contact
+--------------------------------------------------------------------------- */
+.contactEmail {
+  margin: var(--space-md) 0 0;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.contactEmail a {
+  color: var(--text-primary);
   font-weight: 500;
   transition: color var(--transition-fast);
 }
 
-.Contact a:hover {
+.contactEmail a:hover {
   color: var(--accent-secondary);
 }
 
-/* Responsive Styles */
-@media (max-width: 980px) {
-  .Home {
-    padding: var(--space-md);
+.contactEmail a:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ---------------------------------------------------------------------------
+   Responsive — breakpoints: 640px and 1024px only
+--------------------------------------------------------------------------- */
+@media (min-width: 640px) {
+  /* Side-by-side aside cards on tablet widths */
+  .workAside {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 768px) {
-  .Home {
-    padding: var(--space-md) 12px;
+@media (min-width: 1024px) {
+  .workRow {
+    grid-template-columns: minmax(0, 1fr) 280px;
   }
 
-  .Container {
-    margin-top: 0;
+  .workAside {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .basicRow,
-  .workExperienceRow {
-    flex-direction: column;
-    width: 100%;
+  .nowGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .content {
+    padding: 0 var(--space-md);
   }
 
-  .basicRow .basic,
-  .workExperienceRow .workExperience {
-    flex: 1;
-    width: 100%;
+  .section {
+    margin-top: var(--space-3xl);
   }
 
-  .rightColumn {
-    flex: 1;
-    align-items: center;
-    width: 100%;
+  .hero {
+    margin-top: var(--space-2xl);
   }
 
-  .basic {
-    text-align: center;
-    width: 100%;
+  .heroTitle {
+    font-size: 2rem;
+  }
+
+  .heroLede {
+    font-size: 1rem;
+  }
+
+  .workCard {
     padding: var(--space-lg) var(--space-md);
   }
 
-  .basic h2 {
-    text-align: center;
-  }
-
-  .basic p {
-    text-align: center;
-  }
-
-  .College {
+  a.researchLink {
     width: 100%;
-    max-width: 300px;
+    justify-content: center;
   }
 
-  .workExperience {
-    padding: var(--space-lg) var(--space-md);
-    text-align: center;
-  }
-
-  .MiscProjContainer {
+  .miscProjContainer {
     min-height: 0;
-    margin-bottom: 0;
-  }
-
-  .sectionTitle {
-    font-size: 1.3rem;
   }
 }
 
-@media (max-width: 480px) {
-  .Home {
-    padding: 12px 8px;
-  }
-
-  .basic {
-    padding: var(--space-md) 12px;
-  }
-
-  .workExperience {
-    padding: var(--space-md) 12px;
+@media (prefers-reduced-motion: reduce) {
+  a.researchLink,
+  a.researchLink:hover {
+    transition: none;
+    transform: none;
   }
 }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -111,18 +111,23 @@ a.researchLink:focus-visible,
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: var(--space-lg);
-  align-items: start;
+  /* stretch: at desktop the experience card must equal the full height of
+     the aside column (coding-time card + NEU card) so the row bottoms align */
+  align-items: stretch;
 }
 
 .workCard {
   padding: var(--space-lg);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .workAside {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: var(--space-lg);
-  align-items: start;
 }
 
 .college {
@@ -251,6 +256,9 @@ a.researchLink:hover {
 
   .workAside {
     grid-template-columns: minmax(0, 1fr);
+    /* coding-time card keeps its natural height; the NEU card absorbs the
+       rest so the aside column exactly fills the stretched row */
+    grid-template-rows: auto 1fr;
   }
 
   .nowGrid {


### PR DESCRIPTION
## Summary
- Reorders the home page for a professional scroll: hero → social links → work experience → skills → research → misc projects → writing → compact "Now" band (Oura + Kalshi, 2 columns ≥1024px, stacked below) → contact
- Rebuilds the intro as a proper hero: small eyebrow label with a brass tick, `h1`, 65ch lede at 1.125rem; brass `:focus-visible` rings via `var(--accent-brand, #d4a24e)` fallback
- Enforces the shared section rhythm (`--space-4xl` desktop / `--space-3xl` below 640px) and switches to the global `.section-title` / `.glass-card` utilities instead of local duplicates
- Standardizes all breakpoints in owned CSS to 640px/1024px; polishes footer styles (13px secondary text, token spacing)
- Per coordinator note: page wrapper now uses `overflow-x: clip` (sticky-nav safe) and the horizontal gutter moved below the nav so the Bar spans the full row

## Preserved
- Splashscreen machinery verbatim (`NameAnim`, `sessionStorage("loaded")` gate, 2200ms/400ms timers, `fade-out`/`fade-in` classes)
- Lazy MiscProj loading (Suspense + `useIntersectionObserver` gating)
- Only owned files touched: `app/page.js`, `app/page.module.css`, `app/landing.css`

## Testing
- `npm run build` passes (lint is broken identically on untouched main: missing `typescript` module in shared node_modules)
- Dev server e2e on :3103 — HTTP 200 with correct section order and single `h1`
- Splash integrity greps pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)