### PR TITLE
Unit 1: Design tokens, typography & a11y foundation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,8 @@
-/* Global Font Imports */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
+/* Global Font Imports
+   Inter is self-hosted via next/font in app/layout.js (exposed as --font-inter).
+   Caveat stays as a global import — the splashscreen and Bar rely on the
+   globally-loaded 'Caveat' family name. */
 @import url("https://fonts.googleapis.com/css2?family=Caveat:wght@700&display=swap");
-@import url("https://use.typekit.net/cxf0gov.css");
 
 /* CSS Variables — Dark (default) */
 :root,
@@ -12,12 +13,15 @@
   --bg-card-hover: rgba(255, 255, 255, 0.045);
   --accent-primary: #b0b0b0;
   --accent-secondary: #e0e0e0;
+  --accent-brand: #d4a24e;
   --accent-glow: rgba(180, 180, 180, 0.06);
+  --success: #4ade80;
+  --danger: #f87171;
   --text-primary: #e8e8e8;
   --text-secondary: #8a8a8a;
-  --text-muted: #555555;
-  --border-color: rgba(255, 255, 255, 0.06);
-  --border-hover: rgba(255, 255, 255, 0.14);
+  --text-muted: #7a7a7a;
+  --border-color: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(255, 255, 255, 0.2);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.35);
   --shadow-lg: 0 6px 24px rgba(0, 0, 0, 0.45);
@@ -51,12 +55,15 @@
   --bg-card-hover: rgba(0, 0, 0, 0.04);
   --accent-primary: #444444;
   --accent-secondary: #1a1a1a;
+  --accent-brand: #8a6216;
   --accent-glow: rgba(0, 0, 0, 0.04);
+  --success: #15803d;
+  --danger: #b91c1c;
   --text-primary: #111111;
   --text-secondary: #555555;
-  --text-muted: #999999;
-  --border-color: rgba(0, 0, 0, 0.07);
-  --border-hover: rgba(0, 0, 0, 0.14);
+  --text-muted: #6b6b6b;
+  --border-color: rgba(0, 0, 0, 0.1);
+  --border-hover: rgba(0, 0, 0, 0.18);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 6px 24px rgba(0, 0, 0, 0.08);
@@ -73,8 +80,12 @@
   padding: 0;
 }
 
+/* overflow-x: clip (with hidden fallback for older browsers) guards against
+   horizontal overflow without creating a scroll container, so descendant
+   position: sticky elements keep working. */
 html {
   overflow-x: hidden;
+  overflow-x: clip;
   width: 100%;
   scroll-behavior: smooth;
 }
@@ -83,13 +94,16 @@ body {
   background-color: var(--bg-primary);
   display: flex;
   justify-content: center;
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-inter, "Inter"), -apple-system, BlinkMacSystemFont,
+    sans-serif;
+  font-size: 1rem;
   color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   padding: 0;
   margin: 0;
   overflow-x: hidden;
+  overflow-x: clip;
   width: 100%;
   min-height: 100vh;
   line-height: 1.6;
@@ -102,28 +116,30 @@ main {
   width: 100%;
   max-width: var(--max-width);
   overflow-x: hidden;
+  overflow-x: clip;
   padding: 0;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   main {
-    padding: 0 12px;
+    padding: 0 var(--space-lg);
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 640px) {
   main {
-    padding: 0 8px;
+    padding: 0 var(--space-md);
   }
 }
 
 /* Global Typography */
 h1, h2, h3, h4, h5, h6 {
   color: var(--text-primary);
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-inter, "Inter"), -apple-system, BlinkMacSystemFont,
+    sans-serif;
   font-weight: 600;
   letter-spacing: -0.02em;
-  line-height: 1.3;
+  line-height: 1.2;
 }
 
 h1 { font-size: 2.5rem; }
@@ -131,7 +147,8 @@ h2 { font-size: 1.75rem; }
 h3 { font-size: 1.25rem; }
 
 p {
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-inter, "Inter"), -apple-system, BlinkMacSystemFont,
+    sans-serif;
   font-weight: 400;
   color: var(--text-secondary);
   line-height: 1.7;
@@ -144,7 +161,13 @@ a {
 }
 
 a:hover {
-  color: var(--accent-secondary);
+  color: var(--accent-brand);
+}
+
+/* Accessible focus ring */
+:focus-visible {
+  outline: 2px solid var(--accent-brand);
+  outline-offset: 2px;
 }
 
 /* Fade Animations */
@@ -176,19 +199,26 @@ a:hover {
   font-size: 1rem;
 }
 
-/* Glass Card Utility */
+/* Glass Card Utility — the canonical card */
 .glass-card {
   background: var(--bg-card);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  transition: all var(--transition-slow);
+  padding: var(--space-lg);
+  transition:
+    transform var(--transition-base),
+    border-color var(--transition-base),
+    box-shadow var(--transition-base),
+    background-color var(--transition-base);
 }
 
 .glass-card:hover {
   background: var(--bg-card-hover);
   border-color: var(--border-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
 }
 
 /* Section Title Utility */
@@ -205,9 +235,35 @@ a:hover {
   content: "";
   display: block;
   width: 40px;
-  height: 1px;
-  background: var(--text-muted);
+  height: 2px;
+  background: var(--accent-brand);
   margin: 12px auto 0;
   border-radius: 1px;
-  opacity: 0.4;
+}
+
+/* Reduced Motion — disable decorative animation.
+   The splashscreen's SVG stroke draw (.path/.cPath, inline-style transitions
+   set by NameAnim.js) is intentionally exempt. .fade-in must still resolve
+   to visible content. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *:not(.path):not(.cPath),
+  *:not(.path):not(.cPath)::before,
+  *:not(.path):not(.cPath)::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .glass-card:hover {
+    transform: none;
+  }
+
+  .fade-in {
+    animation: none;
+    opacity: 1;
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -120,6 +120,15 @@ main {
   padding: 0;
 }
 
+/* The route template wraps every page in a bare <div>. As a centered flex
+   item it would shrink-wrap to its content's intrinsic width, making page
+   width depend on what has loaded (narrow while skeletons show, wider once
+   charts/cards mount) and differ between routes. Pin it to the full main
+   box so every page gets the same stable width. */
+main > div {
+  width: 100%;
+}
+
 @media (max-width: 1024px) {
   main {
     padding: 0 var(--space-lg);

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,5 +1,12 @@
 import "./globals.css";
+import { Inter } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+});
 
 export const metadata = {
   metadataBase: new URL("https://ashwiniyer.com"),
@@ -26,11 +33,11 @@ export default function RootLayout({ children }) {
   const themeScript = `(function(){try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}})()`;
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning className={inter.variable}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
-      <body>
+      <body className={inter.className}>
         <main>
           {children}
           <footer>


### PR DESCRIPTION
## Summary

Foundation unit of the 13-unit portfolio modernization. Touches only `app/globals.css` and `app/layout.js`.

### Tokens (both themes)
- New additive tokens: `--accent-brand` (dark `#d4a24e`, light `#8a6216`), `--success` (dark `#4ade80`, light `#15803d`), `--danger` (dark `#f87171`, light `#b91c1c`) — consumed by sibling units (link hover, focus ring, section-title underline here; P&L colors in widget units)
- AA-contrast `--text-muted` (dark `#7a7a7a`, light `#6b6b6b`)
- Stronger borders: dark `rgba(255,255,255,.10)/.20`, light `rgba(0,0,0,.10)/.18`
- All existing token names preserved

### Fonts
- Inter migrated from render-blocking Google Fonts `@import` to self-hosted `next/font/google` — `inter.variable` on `<html>` (exposes `--font-inter`), `inter.className` on `<body>`; globals.css stacks now `var(--font-inter, "Inter"), -apple-system, ...`
- Dead Typekit `@import` removed (grep-verified: zero consumers)
- Caveat `@import` kept (splash + Bar rely on the global family name)

### A11y
- Global `:focus-visible { outline: 2px solid var(--accent-brand); outline-offset: 2px; }`
- `prefers-reduced-motion` block neutralizes decorative animation/transitions; splash SVG stroke draw (`.path`/`.cPath`) exempted via `:not()`, and `.fade-in` explicitly resolves to `opacity: 1` so content never stays invisible

### Type / layout / utilities
- Headings line-height 1.2; explicit 1rem body size; h1/h2/h3 scale per brief
- `.glass-card` upgraded to the canonical card spec (padding `--space-lg`, explicit-property transitions — no `transition: all` — hover translateY(-2px) + `--shadow-md` + `--bg-card-hover`; hover transform disabled under reduced motion)
- `.section-title::after` now a 2px brass rule
- `main` responsive padding standardized to 640px/1024px breakpoints
- Per coordinator note for the sticky nav unit: `overflow-x: hidden` → `clip` (with `hidden` fallback) on html/body/main so `position: sticky` works

### Splashscreen — preserved exactly
`--splash-bg`/`--splash-stroke`/`--logo-color` in both themes, `.fade-out`/`.fade`/`.fade-in`, `@keyframes fadeIn`, pre-paint theme-init script, metadata, Google Analytics, footer markup all untouched.

## Cross-unit notes for the coordinator (out of this unit's file ownership)
1. **Literal `"Inter"` stacks in other units' files** — `app/components/Bar.css:34`, `app/components/ProjectList.module.css:37/104/127/194`, `app/blog/[slug]/page.css:32/43/54/65` hardcode `font-family: "Inter", ...`. next/font registers a hashed family, so those rules fall back to system fonts unless changed to `inherit` or `var(--font-inter, "Inter"), ...` by their owning units.
2. **`outline: none`** on `.searchInput` (`ProjectList.module.css:36`) can tie-break over the new global focus ring — its owning unit should remove it per brief §5.
3. Scoped `a:hover` overrides (`page.module.css:72/254`, `Bar.css:45`, blog CSS) predate the brass hover and should be reconciled by their owners per brief §4.

## Testing
- `npm run build` passes (lint is broken identically on `main`: missing `typescript` module in shared node_modules — pre-existing)
- Dev server on :3101 — `/` and `/about` return 200 with static markers; served CSS verified to contain the self-hosted Inter `@font-face`s, `--accent-brand`, `:focus-visible`, `prefers-reduced-motion`, `overflow-x: clip`, Caveat import, and no Typekit
- Splash integrity: `--splash-*` vars, `.fade*` classes, and `@keyframes fadeIn` confirmed present in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)