### PR TITLE
Unit 4: Modernize About page (glass-card grid, section rhythm, resume CTA)

### DIFF
--- a/app/about/About.module.css
+++ b/app/about/About.module.css
@@ -1,62 +1,47 @@
-/* About Page Styles */
+/* About Page Styles
+   Cards compose the global .glass-card utility; only layout lives here.
+   Section titles use the global .section-title utility. */
 
+/* No padding here: Bar sits at the top full-width (it is sticky, so no
+   overflow-x: hidden ancestors — clip does not create a scroll container).
+   Content padding lives on .mainContent below. */
 .About {
-  padding: var(--space-lg);
   max-width: 1200px;
   width: 100%;
   text-align: left;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
-.Container {
-  margin-top: var(--space-lg);
-  width: 100%;
-}
-
+/* Shared section rhythm: --space-4xl desktop, --space-3xl below 640px */
 .mainContent {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2xl);
+  gap: var(--space-4xl);
   width: 100%;
+  margin-top: var(--space-xl);
+  padding: 0 var(--space-lg) var(--space-2xl);
 }
 
-/* Section Titles */
-.sectionTitle {
-  color: var(--text-primary);
-  font-size: 1.5rem;
-  margin-bottom: var(--space-lg);
-  font-weight: 600;
-  text-align: left;
-  letter-spacing: -0.02em;
+/* About cards — equal-weight grid */
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-lg);
+  align-items: stretch;
 }
 
-/* Card Styles */
 .card {
-  background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  padding: var(--space-xl);
-  border: 1px solid var(--border-color);
-  margin-bottom: var(--space-lg);
-  transition: all var(--transition-slow);
+  padding: var(--space-lg);
 }
 
-.card:hover {
-  border-color: var(--border-hover);
-  /* subtle hover */
+.card h3 {
+  margin-bottom: var(--space-md);
 }
 
-.card h3,
-.cardSubtitle {
-  color: var(--text-primary);
-  font-size: 1.15rem;
-  margin-bottom: 12px;
-  font-weight: 600;
-}
-
+/* Color and line-height come from the global p rule */
 .card p {
-  color: var(--text-secondary);
-  line-height: 1.7;
-  font-size: 0.95rem;
+  font-size: 1rem;
+  max-width: 65ch;
 }
 
 .card p b {
@@ -64,203 +49,145 @@
   font-weight: 600;
 }
 
+/* Inline link inside card prose */
 .projectLink {
-  color: var(--accent-primary);
-  text-decoration: none;
+  color: var(--text-primary);
   font-weight: 500;
-  transition: color var(--transition-fast);
+  text-decoration: underline;
+  text-decoration-color: var(--text-secondary);
+  text-underline-offset: 3px;
+  transition: color var(--transition-fast),
+    text-decoration-color var(--transition-fast);
 }
 
 .projectLink:hover {
   color: var(--accent-secondary);
+  text-decoration-color: var(--accent-brand, #d4a24e);
 }
 
-/* Intro Section */
-.introSection {
+.projectLink:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Connect section */
+.connectRow {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  gap: var(--space-xl);
 }
 
-/* Links Section */
-.linksSection {
-  display: flex;
-  flex-direction: column;
-}
-
-.linksCard {
-  background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  padding: var(--space-xl);
-  border: 1px solid var(--border-color);
+.linksWrap {
+  width: 100%;
+  max-width: 420px;
   display: flex;
   justify-content: center;
+}
+
+/* Resume CTA — button-style link */
+.resumeCta {
+  display: inline-flex;
   align-items: center;
-  margin-bottom: var(--space-lg);
-  transition: all var(--transition-slow);
-}
-
-.linksCard:hover {
-  border-color: var(--border-hover);
-  /* subtle hover */
-}
-
-/* Resume Link */
-.resumeLink {
-  text-decoration: none;
-  transition: transform var(--transition-base);
-  display: block;
-}
-
-.resumeLink:hover {
-  transform: translateY(-3px);
-}
-
-.resumeCard {
+  gap: var(--space-sm);
+  padding: 12px var(--space-xl);
   background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  padding: var(--space-xl);
   border: 1px solid var(--border-color);
-  text-align: center;
-  transition: all var(--transition-slow);
-}
-
-.resumeCard:hover {
-  border-color: var(--border-hover);
-  /* subtle hover */
-}
-
-.resumeCard h3 {
+  border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 1.15rem;
-  margin-bottom: 8px;
-  font-weight: 600;
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition: background-color var(--transition-base),
+    border-color var(--transition-base), transform var(--transition-base),
+    box-shadow var(--transition-base);
 }
 
-.resumeCard p {
-  color: var(--text-secondary);
-  font-size: 0.9rem;
+.resumeCta:hover {
+  color: var(--text-primary);
+  background: var(--bg-card-hover);
+  border-color: var(--border-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
 }
 
-/* Music Section */
-.musicSection {
-  display: flex;
-  flex-direction: column;
+.resumeCta:focus-visible {
+  outline: 2px solid var(--accent-brand, #d4a24e);
+  outline-offset: 2px;
 }
 
+.ctaArrow {
+  display: inline-block;
+  transition: transform var(--transition-base);
+}
+
+.resumeCta:hover .ctaArrow {
+  transform: translateX(3px);
+}
+
+/* Songs section */
 .songsCard {
-  background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  padding: var(--space-xl);
-  border: 1px solid var(--border-color);
-  transition: all var(--transition-slow);
+  padding: var(--space-lg);
 }
 
-.songsCard:hover {
-  border-color: var(--border-hover);
-  /* subtle hover */
-}
-
-/* Oura Section */
-.ouraSection {
-  margin-top: var(--space-xl);
-}
-
+/* Oura section — no padding: the dashboard's dark panel fills the card
+   edge-to-edge and overflow clips it to the rounded corners */
 .ouraCard {
-  background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-color);
+  width: 100%;
   overflow: hidden;
-  transition: all var(--transition-slow);
 }
 
-.ouraCard:hover {
-  border-color: var(--border-hover);
-  /* subtle hover */
+/* Clash of Clans — component brings its own top/side padding */
+.cocCard {
+  width: 100%;
+  padding-bottom: var(--space-lg);
 }
 
-/* COC Section */
-.cocSection {
-  margin-top: var(--space-lg);
+/* Responsive Styles — breakpoints: 1024px / 640px only */
+@media (max-width: 1024px) {
+  .cardGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .card:last-child {
+    grid-column: 1 / -1;
+  }
 }
 
-/* Responsive Styles */
-@media (max-width: 980px) {
-  .About {
+@media (max-width: 640px) {
+  .cardGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .card:last-child {
+    grid-column: auto;
+  }
+
+  .mainContent {
+    gap: var(--space-3xl);
+    margin-top: var(--space-md);
+    padding: 0 12px var(--space-2xl);
+  }
+
+  .card,
+  .songsCard {
     padding: var(--space-md);
   }
-
-  .Container {
-    padding-left: var(--space-md);
-    padding-right: var(--space-md);
-    margin-top: 0;
-  }
 }
 
-@media (max-width: 768px) {
-  .About {
-    padding: var(--space-md) 12px;
-    text-align: center;
+@media (prefers-reduced-motion: reduce) {
+  .resumeCta,
+  .ctaArrow,
+  .projectLink {
+    transition: none;
   }
 
-  .sectionTitle {
-    font-size: 1.3rem;
-    text-align: center;
+  .resumeCta:hover {
+    transform: none;
   }
 
-  .card {
-    padding: var(--space-lg) var(--space-md);
-    text-align: center;
-  }
-
-  .card h3 {
-    font-size: 1.1rem;
-    text-align: center;
-  }
-
-  .card p {
-    font-size: 0.9rem;
-    text-align: center;
-  }
-
-  .resumeCard {
-    padding: var(--space-lg) var(--space-md);
-  }
-
-  .resumeCard h3 {
-    font-size: 1.1rem;
-  }
-
-  .resumeCard p {
-    font-size: 0.9rem;
-  }
-
-  .linksCard {
-    padding: var(--space-lg) var(--space-md);
-  }
-
-  .songsCard {
-    padding: var(--space-lg) var(--space-md);
-  }
-}
-
-@media (max-width: 480px) {
-  .About {
-    padding: 12px 8px;
-  }
-
-  .card {
-    padding: var(--space-md) 12px;
-  }
-
-  .resumeCard {
-    padding: var(--space-md) 12px;
-  }
-
-  .linksCard {
-    padding: var(--space-md) 12px;
-  }
-
-  .songsCard {
-    padding: var(--space-md) 12px;
+  .resumeCta:hover .ctaArrow {
+    transform: none;
   }
 }

--- a/app/about/About.module.css
+++ b/app/about/About.module.css
@@ -167,7 +167,9 @@
   .mainContent {
     gap: var(--space-3xl);
     margin-top: var(--space-md);
-    padding: 0 12px var(--space-2xl);
+    /* --space-md matches the home page's mobile gutter (the site-wide
+       source of truth) so /about is exactly as wide as / on phones */
+    padding: 0 var(--space-md) var(--space-2xl);
   }
 
   .card,

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -42,9 +42,7 @@ export default function About() {
             <div className={`glass-card ${styles.card}`}>
               <h3>Interests</h3>
               <p>
-                Beyond coding, I enjoy working out and listening to music, with
-                the occasional game of Clash of Clans. My top tracks and health
-                stats are just below.
+                Beyond coding, I enjoy working out, listening to music, and reading about financial markets. My top tracks and health stats are just below.
               </p>
             </div>
           </div>

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -11,12 +11,12 @@ export default function About() {
   return (
     <div className={styles.About}>
       <Bar />
-      <div className={styles.Container}>
-        <div className={styles.mainContent}>
-          <div className={styles.introSection}>
-            <h2 className={styles.sectionTitle}>About Me</h2>
-            <div className={styles.card}>
-              <h3 className={styles.cardSubtitle}>Education</h3>
+      <div className={styles.mainContent}>
+        <section>
+          <h2 className="section-title">About Me</h2>
+          <div className={styles.cardGrid}>
+            <div className={`glass-card ${styles.card}`}>
+              <h3>Education</h3>
               <p>
                 My name is Ashwin Iyer, a current sophomore at{" "}
                 <b>Northeastern University</b> studying{" "}
@@ -25,12 +25,12 @@ export default function About() {
                 <b>finance</b> and the <b>computer science</b> clubs on campus.
               </p>
             </div>
-            
-            <div className={styles.card}>
-              <h3 className={styles.cardSubtitle}>Experience & Projects</h3>
+
+            <div className={`glass-card ${styles.card}`}>
+              <h3>Experience &amp; Projects</h3>
               <p>
-                I have been hobby coding for around 10~ years and have competed
-                in 2 hackathons, <b>HackUTD</b> and <b>AIFAHacks</b>, winning
+                I have been hobby coding for around 10 years and have competed
+                in two hackathons, <b>HackUTD</b> and <b>AIFAHacks</b>, winning
                 both competitions. I currently have a few side{" "}
                 <Link href="/projects" className={styles.projectLink}>
                   projects
@@ -39,45 +39,51 @@ export default function About() {
               </p>
             </div>
 
-            <div className={styles.card}>
-              <h3 className={styles.cardSubtitle}>Interests</h3>
+            <div className={`glass-card ${styles.card}`}>
+              <h3>Interests</h3>
               <p>
-                Beyond coding, I enjoy working out and listening to music 🎵!
+                Beyond coding, I enjoy working out and listening to music, with
+                the occasional game of Clash of Clans. My top tracks and health
+                stats are just below.
               </p>
             </div>
           </div>
+        </section>
 
-          <div className={styles.linksSection}>
-            <h2 className={styles.sectionTitle}>Connect With Me</h2>
-            <div className={styles.linksCard}>
+        <section>
+          <h2 className="section-title">Connect With Me</h2>
+          <div className={styles.connectRow}>
+            <div className={styles.linksWrap}>
               <Links />
             </div>
-            <Link href="/resume" className={styles.resumeLink}>
-              <div className={styles.resumeCard}>
-                <h3>View My Resume</h3>
-                <p>Check out my full professional background →</p>
-              </div>
+            <Link href="/resume" className={styles.resumeCta}>
+              View my resume
+              <span className={styles.ctaArrow} aria-hidden="true">
+                &rarr;
+              </span>
             </Link>
           </div>
+        </section>
 
-          <div className={styles.musicSection}>
-            <h2 className={styles.sectionTitle}>My Top Songs This Week</h2>
-            <div className={styles.songsCard}>
-              <SongList />
-            </div>
-
-          <div className={styles.ouraSection}>
-             <h2 className={styles.sectionTitle}>My Health Stats (Oura)</h2>
-             <div className={styles.ouraCard} style={{ width: '100%', overflow: 'hidden' }}>
-                <OuraDashboard />
-             </div>
+        <section>
+          <h2 className="section-title">Top Songs This Week</h2>
+          <div className={`glass-card ${styles.songsCard}`}>
+            <SongList />
           </div>
-          </div>
+        </section>
 
-          <div className={styles.cocSection}>
+        <section>
+          <h2 className="section-title">Health Stats (Oura)</h2>
+          <div className={`glass-card ${styles.ouraCard}`}>
+            <OuraDashboard showHeader={false} />
+          </div>
+        </section>
+
+        <section>
+          <div className={`glass-card ${styles.cocCard}`}>
             <Coc />
           </div>
-        </div>
+        </section>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Restructures the About page into an equal-weight grid of cards composed with the global `.glass-card` utility (Education / Experience & Projects / Interests): 3-col desktop, 2-col with a spanning last card on tablet, 1-col below 640px. Only layout styles remain in the module.
- Applies the shared section rhythm (`--space-4xl` between sections desktop, `--space-3xl` below 640px) and the global `.section-title` utility for every section heading (no local re-implementation of the underline).
- Reflows the page: about cards -> Connect (Links + resume CTA) -> Top Songs -> Health Stats (Oura) -> Clash of Clans. Removes the double-card wrapper around `Links`, hides OuraDashboard's internal duplicate header via its existing `showHeader` prop, and keeps the Oura card padding-free so its dark panel clips to the rounded corners.
- Replaces the resume card with an accessible button-style CTA: explicit-property transitions, hover lift per the design brief (translateY(-2px) + border/shadow), brass `:focus-visible` ring via `var(--accent-brand, #d4a24e)` static fallback, and a `prefers-reduced-motion` block.
- Raises all card body text to 1rem, caps prose at 65ch, and standardizes breakpoints to exactly 640px/1024px.
- Nav-unit compatibility: `Bar` no longer sits inside a padded wrapper, and the page wrapper uses `overflow-x: clip` (not `hidden`) so the sibling unit's sticky nav keeps working; content padding moved to the content container below the bar.

Only `app/about/page.js` and `app/about/About.module.css` are touched.

## Notes for reviewers
- `--accent-brand` is defined in the tokens unit's PR; this page references it only with the mandated static fallback. Until that token lands (ideally theme-aware), the brass fallback has low contrast in light theme, so the inline project link uses a theme-aware hover color with brass reserved for the underline detail and focus rings per the brief.
- `npm run lint` fails on main and this branch identically ("Cannot find module 'typescript'" from eslint-config-next) — pre-existing environment issue, not introduced here.

## Test plan
- `npm run build` passes (17/17 static pages).
- `next dev -p 3104`: `GET /about` returns 200; education/Northeastern copy, all five sections, `glass-card`/`section-title` classes, and the resume CTA render in the HTML. Live-data widgets (songs/Oura) show local loading/error states as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)