### PR TITLE
Unit 12: modernize song list, Clash of Clans stats, and censored-image reveal

### DIFF
--- a/app/components/COC.js
+++ b/app/components/COC.js
@@ -11,20 +11,77 @@ const townHallImages = {
   16: townHall16,
 };
 
+const formatNumber = (value) =>
+  typeof value === "number" ? value.toLocaleString("en-US") : value ?? "";
+
 export default function COC() {
   const { townHallLevel } = COCData;
   const townHallImage = townHallImages[townHallLevel];
 
+  const stats = [
+    {
+      label: "Best Trophies",
+      value: formatNumber(COCData.bestTrophies),
+      className: `${styles.statValue} ${styles.trophies}`,
+    },
+    {
+      label: "War Stars",
+      value: formatNumber(COCData.warStars),
+      className: styles.statValue,
+    },
+    {
+      label: "Exp Level",
+      value: formatNumber(COCData.expLevel),
+      className: styles.statValue,
+    },
+  ];
+
   return (
-    <div className={styles.container}>
-      <h2>Clash of Clans</h2>
-      <p>Username: {COCData.name}</p>
-      <p>TH Level: {townHallLevel}</p>
-      {townHallImage && (
-        <Image src={townHallImage} alt={`Town Hall Level ${townHallLevel}`} />
-      )}
-      <p>Trophies: {COCData.bestTrophies}</p>
-      <img src={COCData.league.iconUrls.tiny} alt="League Icon" />
-    </div>
+    <section className={styles.coc}>
+      <h2 className="section-title">Clash of Clans</h2>
+      <div className={`glass-card ${styles.card}`}>
+        {townHallImage && (
+          <figure className={styles.townHall}>
+            <Image
+              src={townHallImage}
+              alt={`Town Hall level ${townHallLevel}`}
+              className={styles.townHallImage}
+            />
+            <figcaption className={styles.townHallCaption}>
+              Town Hall {townHallLevel}
+            </figcaption>
+          </figure>
+        )}
+        <div className={styles.details}>
+          <p className={styles.playerName}>{COCData.name}</p>
+          <p className={styles.playerMeta}>
+            {COCData.clan?.name} · {COCData.tag}
+          </p>
+          <dl className={styles.stats}>
+            {COCData.league?.name && (
+              <div className={styles.stat}>
+                <dt className={styles.statLabel}>League</dt>
+                <dd className={styles.statValue}>
+                  {COCData.league.iconUrls?.tiny && (
+                    <img
+                      src={COCData.league.iconUrls.tiny}
+                      alt=""
+                      className={styles.leagueIcon}
+                    />
+                  )}
+                  {COCData.league.name}
+                </dd>
+              </div>
+            )}
+            {stats.map((stat) => (
+              <div className={styles.stat} key={stat.label}>
+                <dt className={styles.statLabel}>{stat.label}</dt>
+                <dd className={stat.className}>{stat.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/app/components/COC.module.css
+++ b/app/components/COC.module.css
@@ -1,65 +1,137 @@
-.container {
-  display: flex;
-  flex-direction: column; /* Change to 'row' if you want everything in a single row */
-  align-items: center; /* Center items horizontally */
-  text-align: center; /* Center text within each item */
-  padding: 20px; /* Add some padding */
-  padding-bottom: 0px;
-  overflow-x: hidden;
+/* COC.module.css */
+
+.coc {
   width: 100%;
 }
 
-.container h2 {
-  margin-bottom: 10px; /* Space between heading and first paragraph */
-  text-align: center;
+.card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xl);
+  padding: var(--space-lg);
 }
 
-.container p {
-  margin: 5px 0; /* Space between paragraphs */
-  max-width: 100%;
-  text-align: center;
+/* Scoped as .coc .card so the explicit transition list reliably wins
+   over the global .glass-card { transition: all } at equal specificity. */
+.coc .card {
+  transition: transform var(--transition-base),
+    background-color var(--transition-base),
+    border-color var(--transition-base), box-shadow var(--transition-base);
 }
 
-.container img {
-  margin-top: 10px; /* Space above the image */
-  width: 50px; /* Set a fixed width for the image */
-  height: auto; /* Maintain aspect ratio */
-}
-
-@media (max-width: 767px) {
-  .container {
-    padding: 16px 12px;
-    padding-bottom: 0;
-  }
-
-  .container h2 {
-    font-size: 1.3rem;
-  }
-
-  .container p {
-    font-size: 0.9rem;
-  }
-
-  .container img {
-    width: 40px;
+/* background/border hover come from the composed global .glass-card */
+@media (hover: hover) {
+  .card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
   }
 }
 
-@media (max-width: 480px) {
-  .container {
-    padding: 12px 8px;
-    padding-bottom: 0;
+.townHall {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  margin: 0;
+}
+
+.townHallImage {
+  width: 160px;
+  height: auto;
+  border-radius: var(--radius-md);
+}
+
+.townHallCaption,
+.statLabel,
+.playerMeta {
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+}
+
+.details {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.playerName {
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.playerMeta {
+  margin: var(--space-xs) 0 0;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-md) var(--space-lg);
+  margin: var(--space-lg) 0 0;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.statValue {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  font-size: 1rem;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.trophies {
+  font-weight: 600;
+  color: var(--accent-brand, #d4a24e);
+}
+
+.leagueIcon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+}
+
+@media (max-width: 640px) {
+  .card {
+    flex-direction: column;
+    gap: var(--space-lg);
   }
 
-  .container h2 {
-    font-size: 1.2rem;
+  .townHallImage {
+    width: 132px;
   }
 
-  .container p {
-    font-size: 0.85rem;
+  .details {
+    width: 100%;
+    text-align: center;
   }
 
-  .container img {
-    width: 35px;
+  .stat {
+    align-items: center;
+  }
+
+  .statValue {
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .coc .card {
+    transition: background-color var(--transition-base),
+      border-color var(--transition-base), box-shadow var(--transition-base);
+  }
+
+  .card:hover {
+    transform: none;
   }
 }

--- a/app/components/CensoredImage.js
+++ b/app/components/CensoredImage.js
@@ -3,14 +3,62 @@
 import { useState } from "react";
 import Image from "next/image";
 
+const imageStyle = {
+  transition:
+    "filter var(--transition-base), transform var(--transition-base)",
+};
+
+// Older engines throw when matches() is given an unknown pseudo-class;
+// default to showing the outline so keyboard users never lose it.
+const isFocusVisible = (element) => {
+  try {
+    return element.matches(":focus-visible");
+  } catch {
+    return true;
+  }
+};
+
 const CensoredImage = ({ src, alt, caption }) => {
   const [revealed, setRevealed] = useState(false);
+  const [focusVisible, setFocusVisible] = useState(false);
+
+  const reveal = () => {
+    if (!revealed) {
+      setRevealed(true);
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (revealed) {
+      return; // Let Space/Enter behave normally once there is nothing to do
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      reveal();
+    }
+  };
 
   return (
     <div className="video">
       <div
         className={`image-container ${revealed ? "revealed" : ""}`}
-        onClick={() => setRevealed(true)}
+        onClick={reveal}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-disabled={revealed}
+        aria-label={revealed ? alt : `Reveal image: ${alt}`}
+        onFocus={(event) =>
+          setFocusVisible(isFocusVisible(event.currentTarget))
+        }
+        onBlur={() => setFocusVisible(false)}
+        style={{
+          cursor: revealed ? "default" : "pointer",
+          outline: focusVisible
+            ? "2px solid var(--accent-brand, #d4a24e)"
+            : undefined,
+          outlineOffset: "2px",
+        }}
       >
         <Image
           src={src}
@@ -18,8 +66,19 @@ const CensoredImage = ({ src, alt, caption }) => {
           width={500}
           height={500}
           className="flex-image"
+          style={imageStyle}
         />
-        {!revealed && <div className="overlay">Click to Reveal</div>}
+        <div
+          className="overlay"
+          aria-hidden="true"
+          style={{
+            opacity: revealed ? 0 : 1,
+            pointerEvents: revealed ? "none" : "auto",
+            transition: "opacity var(--transition-base)",
+          }}
+        >
+          Click to Reveal
+        </div>
       </div>
       <p>{caption}</p>
     </div>

--- a/app/components/SongList.js
+++ b/app/components/SongList.js
@@ -1,18 +1,13 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import songsData1 from "../data/songs.json"; // Adjust the path as necessary
-import styles from "./SongList.module.css"; // Import your CSS module
-import Box from "@mui/material/Box"; // Import Box from Material-UI
-import Grid from "@mui/material/Grid"; // Import Grid from Material-UI
+import localSongsData from "../data/songs.json"; // Fallback when the API is unavailable
+import styles from "./SongList.module.css";
 
 const SongList = () => {
   const songRefs = useRef([]);
-  const [isClient, setIsClient] = useState(false); // To track if we are on the client
-  const [windowWidth, setWindowWidth] = useState(0); // Track window width for conditional behavior
   const [songsData, setSongsData] = useState([]); // Store the song data
   const [loading, setLoading] = useState(true); // Track loading state
-  const [animationsReady, setAnimationsReady] = useState(false); // Track if animations should be active
 
   useEffect(() => {
     const fetchSongs = async () => {
@@ -22,8 +17,8 @@ const SongList = () => {
         if (!res.ok) {
           throw new Error("Network response was not ok");
         }
-        const data = await res.json(); // Await the JSON response to get the projects array
-        setSongsData(data);
+        const data = await res.json();
+        setSongsData(Array.isArray(data) ? data : localSongsData);
       } catch (error) {
         console.error(
           "Failed to fetch from API, falling back to local data:",
@@ -31,128 +26,85 @@ const SongList = () => {
         );
 
         // If the fetch fails, use the local JSON file
-        setSongsData(songsData1); // Use the local songs data
+        setSongsData(localSongsData);
       } finally {
-        setLoading(false); // Set loading to false when done
+        setLoading(false);
       }
     };
 
-    fetchSongs(); // Call the fetch function
-  }, []); // Empty dependency array to run once on mount
-
-  useEffect(() => {
-    setIsClient(true); // Set to true after the component mounts
-    // Update window width
-    const handleResize = () => {
-      setWindowWidth(window.innerWidth);
-    };
-    // Set initial window width
-    handleResize();
-    // Add resize listener
-    window.addEventListener("resize", handleResize);
-
-    // Set animations ready after a short delay to ensure DOM is ready
-    const timer = setTimeout(() => {
-      setAnimationsReady(true);
-    }, 100);
-
-    return () => {
-      // Cleanup the resize listener
-      window.removeEventListener("resize", handleResize);
-      clearTimeout(timer);
-    };
+    fetchSongs();
   }, []);
 
   useEffect(() => {
-    // Apply the observer regardless of screen size to ensure animations work properly
-    if (songRefs.current.length > 0 && animationsReady) {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              entry.target.classList.add(styles.show);
-            } else {
-              entry.target.classList.remove(styles.show);
-            }
-          });
-        },
-        {
-          threshold: 0.1, // Trigger when 90% of the item is in view
-          rootMargin: "0px 0px -10px 0px", // Delay animation trigger until items are closer to the viewport
-        }
-      );
+    const items = songRefs.current.filter(Boolean);
+    if (items.length === 0) {
+      return;
+    }
 
-      // Observe each song item Box
-      songRefs.current.forEach((item) => {
-        if (item) {
-          observer.observe(item);
-        }
-      });
+    // Without IntersectionObserver support, show everything immediately.
+    if (typeof IntersectionObserver === "undefined") {
+      items.forEach((item) => item.classList.add(styles.show));
+      return;
+    }
 
-      return () => {
-        songRefs.current.forEach((item) => {
-          if (item) {
-            observer.unobserve(item);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add(styles.show);
+          } else {
+            entry.target.classList.remove(styles.show);
           }
         });
-      };
-    }
-  }, [windowWidth, songsData, animationsReady]);
+      },
+      {
+        threshold: 0.1,
+        rootMargin: "0px 0px -10px 0px",
+      }
+    );
+
+    items.forEach((item) => observer.observe(item));
+
+    return () => {
+      items.forEach((item) => observer.unobserve(item));
+    };
+  }, [songsData]);
 
   if (loading) {
-    return <p>Loading songs...</p>; // Display a loading message
+    return <p className="loading">Loading songs…</p>;
+  }
+
+  if (songsData.length === 0) {
+    return <p className="loading">No songs available right now.</p>;
   }
 
   return (
-    <div className={styles["song-list"]}>
-      {/* Replace Stack with Grid for better column control */}
-      <Grid
-        container
-        spacing={{ xs: 2, md: 0 }}
-        columns={{ xs: 4, sm: 16, md: 32 }}
-        justifyContent={"center"}
-        padding={"0"}
-      >
-        {songsData.length > 0 ? (
-          songsData.map((song, index) => (
-            <Grid size={{ xs: 2, sm: 4, md: 4 }} key={index}>
-              <Box
-                ref={(el) => (songRefs.current[index] = el)}
-                className={`${styles["song-item"]}`}
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  width: "100%",
-                  height: "100%",
-                  opacity: 0,
-                  transform: "translateY(20px)",
-                  transition: "opacity 0.5s ease, transform 0.5s ease",
-                  "&.show": {
-                    opacity: 1,
-                    transform: "translateY(0)",
-                  },
-                }}
-              >
-                <img
-                  src={song.songcoverlink}
-                  alt={`${song.song_name} cover`}
-                  className={styles["song-cover"]}
-                />
-                <div className={styles["song-info"]}>
-                  <h3 className={styles["song-name"]}>{song.song_name}</h3>
-                  <p className={styles["artist-name"]}>{song.artist}</p>
-                </div>
-              </Box>
-            </Grid>
-          ))
-        ) : (
-          <Grid item xs={12}>
-            <p>No songs available</p>
-          </Grid>
-        )}
-      </Grid>
-    </div>
+    <ul className={styles.songList}>
+      {songsData.map((song, index) => (
+        <li
+          key={`${song.song_name}-${index}`}
+          ref={(el) => {
+            songRefs.current[index] = el;
+          }}
+          className={styles.songItem}
+        >
+          <img
+            src={song.songcoverlink}
+            alt={`${song.song_name} cover`}
+            className={styles.songCover}
+            loading="lazy"
+          />
+          <div className={styles.songInfo}>
+            <h3 className={styles.songName} title={song.song_name}>
+              {song.song_name}
+            </h3>
+            <p className={styles.artistName} title={song.artist}>
+              {song.artist}
+            </p>
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 };
 

--- a/app/components/SongList.module.css
+++ b/app/components/SongList.module.css
@@ -1,119 +1,110 @@
 /* SongList.module.css */
 
-.song-list {
+.songList {
+  list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
   justify-content: center;
-  padding: 1rem;
+  gap: var(--space-lg);
   width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
-.song-list p {
-  max-width: 100%;
-}
-
-.song-item {
+/* Deliberately not composed with the global .glass-card: ten tiles animating
+   translateY while each recomputes a 12px backdrop blur is a scroll-jank
+   hazard, so the card surface is declared here without backdrop-filter. */
+.songItem {
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
-  margin: 0 auto;
-  padding: 0.5rem;
-  transition: opacity 0.5s ease, transform 0.5s ease;
+  flex: 1 1 132px;
+  min-width: 112px;
+  max-width: 168px;
+  padding: var(--space-md);
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
   opacity: 0;
   transform: translateY(20px);
+  transition: opacity var(--transition-base), transform var(--transition-base),
+    background-color var(--transition-base),
+    border-color var(--transition-base), box-shadow var(--transition-base);
 }
 
-.song-item.show {
+.songItem.show {
   opacity: 1;
   transform: translateY(0);
 }
 
-.song-cover {
-  width: 100px;
-  height: 100px;
+@media (hover: hover) {
+  .songItem.show:hover {
+    transform: translateY(-2px);
+    background: var(--bg-card-hover);
+    border-color: var(--border-hover);
+    box-shadow: var(--shadow-md);
+  }
+}
+
+.songCover {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
-.song-info {
+.songInfo {
+  width: 100%;
+  min-width: 0;
+  margin-top: var(--space-sm);
   text-align: center;
-  width: 100%;
-  margin-top: 0.5rem;
 }
 
-.song-name {
+.songName {
   font-size: 1rem;
-  margin: 0.5rem 0 0.2rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.35;
+  margin: 0 0 var(--space-xs);
   color: var(--text-primary);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
   overflow: hidden;
-  text-overflow: ellipsis;
-  width: 100%;
 }
 
-.artist-name {
-  font-size: 0.9rem;
-  color: var(--text-muted);
+.artistName {
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+  margin: 0;
+  color: var(--text-secondary);
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 100%;
 }
 
-/* Mobile specific styles */
-@media (max-width: 767px) {
-  .song-list {
-    padding: 0 8px;
-    gap: 0.5rem;
-    justify-content: center;
+@media (max-width: 640px) {
+  .songList {
+    gap: var(--space-md);
   }
 
-  .song-item {
-    max-width: 100%; /* Allow full width on mobile */
-    padding: 0.5rem;
-    text-align: center;
+  .songItem {
+    flex-basis: 124px;
+    min-width: 104px;
   }
+}
 
-  .song-item.mobile {
+@media (prefers-reduced-motion: reduce) {
+  .songItem {
     opacity: 1;
-    transform: translateY(0);
+    transform: none;
+    transition: background-color var(--transition-base),
+      border-color var(--transition-base), box-shadow var(--transition-base);
   }
 
-  .song-info {
-    text-align: center;
-  }
-
-  .song-name {
-    font-size: 0.9rem;
-    text-align: center;
-  }
-
-  .artist-name {
-    font-size: 0.8rem;
-    text-align: center;
-  }
-}
-
-@media (max-width: 480px) {
-  .song-list {
-    padding: 0 4px;
-    gap: 0.4rem;
-  }
-
-  .song-item {
-    padding: 0.4rem;
-  }
-
-  .song-cover {
-    width: 80px;
-    height: 80px;
-  }
-
-  .song-name {
-    font-size: 0.85rem;
-  }
-
-  .artist-name {
-    font-size: 0.75rem;
+  .songItem.show:hover {
+    transform: none;
   }
 }


### PR DESCRIPTION
## Summary
Part of the 13-unit portfolio modernization. This unit owns the About-page widgets: `SongList`, `COC` (Clash of Clans stats), and the `CensoredImage` blur-reveal component (used in blog MDX).

### SongList (`app/components/SongList.js` + module)
- Replaced the MUI Grid/Box layer with a semantic `<ul>` of canonical card tiles: `--bg-card` surface, 1px `--border-color`, `--radius-lg`, `--space-md` tile padding, `--space-lg` grid gap.
- Covers render full-width, square (`aspect-ratio: 1/1`), `--radius-md`.
- Titles 1rem/600 with a 2-line clamp (no lost text vs. single-line truncation); artist meta 0.8125rem `--text-secondary` with 0.02em tracking.
- Canonical hover (translateY(-2px), `--border-hover`, `--shadow-md`, `--bg-card-hover`) gated behind `(hover: hover)`.
- Data fetching, loading, and empty states kept intact; API response is now guarded with `Array.isArray` before render; IntersectionObserver reveal kept, with a no-IO fallback and `prefers-reduced-motion` support. Dead `isClient`/`windowWidth`/`animationsReady` state removed.
- Deliberately not composed with `.glass-card`: ten tiles animating translateY while each recomputes a 12px backdrop blur is a scroll-jank hazard (documented in the module).

### COC (`app/components/COC.js` + module)
- Rebuilt as a single `.glass-card` stat panel under the global `.section-title` heading: town-hall image (`--radius-md`, captioned), player name + clan/tag meta, and a stat grid (League with icon, Best Trophies, War Stars, Exp Level) read from the existing `app/data/COC.json` (untouched).
- Best Trophies carries the one brass accent (`var(--accent-brand, #d4a24e)` with static fallback per the coordination plan).
- Explicit-property transitions scoped as `.coc .card` so they deterministically win over the global `.glass-card { transition: all }`.
- Stacks below 640px; all text ≥1rem body / ≥0.8125rem labels.

### CensoredImage (`app/components/CensoredImage.js`)
- Keyboard-accessible reveal: `role="button"`, always focusable (activation no longer drops focus to `<body>`), Enter/Space activation that stops eating keys after reveal, `aria-disabled` once revealed.
- Visible brass `:focus-visible` outline, emulated in JS (its stylesheet lives in the blog unit's `page.css`, untouched here) with a try/catch fallback for engines lacking `:focus-visible` in `matches()`.
- Blur/overlay transitions moved to explicit properties on `var(--transition-base)`; reveal behavior and the blog CSS class contract (`video`/`image-container`/`overlay`/`flex-image`/`revealed`) unchanged.

Both themes verified via shared tokens only; breakpoints standardized to 640px; splashscreen untouched.

## Testing
- `npm run build` passes (17/17 static pages). `npm run lint` fails repo-wide before parsing any file (missing `typescript` module in shared `node_modules`) — pre-existing, unrelated to this diff.
- Dev server on :3112 — `/about` returns 200 with the full COC stat panel in SSR HTML and the songs loading state (expected without prod env); `/blog/working-out` returns 200 with the censored-image overlay.
- 10-angle code review + gap sweep run; all confirmed findings fixed (focus loss on reveal, `matches(":focus-visible")` throw, transition cascade nondeterminism, title truncation, latent `formatNumber(undefined)` crash, non-array API guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)